### PR TITLE
feat(security): trusted proxy 신뢰 경계 표준화 및 운영 경고 보강

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,4 +18,5 @@ APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD=change_me_now
 JWT_SECRET=replace_with_base64_secret
 
 # Comma-separated trusted proxy CIDRs for X-Forwarded-For usage
+# Avoid broad trust ranges like 0.0.0.0/0 or ::/0
 TRUSTED_PROXY_SUBNETS=127.0.0.1/32,::1/128

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Detailed specifications and architectural decisions can be found in the `spec/` 
    - `JWT_SECRET` (Base64, decoded length >= 32 bytes)
    - `WG_HOST` (Public IP or DDNS)
    - `WG_PASSWORD_HASH` (wg-easy admin password hash)
+   - `TRUSTED_PROXY_SUBNETS` (X-Forwarded-For를 신뢰할 프록시 CIDR 목록)
+
+   Trusted Proxy 설정 예시:
+   - 로컬 단독: `127.0.0.1/32,::1/128`
+   - 단일 리버스 프록시: `<proxy-ip>/32`
+   - 금지 권장: `0.0.0.0/0`, `::/0` (모든 IP 신뢰)
 
    Generate a secure JWT secret:
    ```bash

--- a/backend/src/test/java/com/manas/backend/common/security/ClientIpResolverTest.java
+++ b/backend/src/test/java/com/manas/backend/common/security/ClientIpResolverTest.java
@@ -1,0 +1,46 @@
+package com.manas.backend.common.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class ClientIpResolverTest {
+
+    @Test
+    @DisplayName("trusted proxy일 때 X-Forwarded-For의 첫 번째 IP를 사용한다")
+    void shouldUseXffWhenRemoteIsTrustedProxy() {
+        ClientIpResolver resolver = new ClientIpResolver("127.0.0.1/32");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        request.addHeader("X-Forwarded-For", "203.0.113.10, 127.0.0.1");
+
+        assertThat(resolver.resolve(request)).isEqualTo("203.0.113.10");
+    }
+
+    @Test
+    @DisplayName("trusted proxy가 아니면 remoteAddr를 사용한다")
+    void shouldUseRemoteAddrWhenProxyNotTrusted() {
+        ClientIpResolver resolver = new ClientIpResolver("10.0.0.0/8");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("192.168.0.2");
+        request.addHeader("X-Forwarded-For", "203.0.113.10");
+
+        assertThat(resolver.resolve(request)).isEqualTo("192.168.0.2");
+    }
+
+    @Test
+    @DisplayName("invalid CIDR는 무시되고, trusted proxy 미설정처럼 동작한다")
+    void shouldIgnoreInvalidCidrAndFallbackToRemoteAddr() {
+        ClientIpResolver resolver = new ClientIpResolver("bad-cidr-value");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("127.0.0.1");
+        request.addHeader("X-Forwarded-For", "203.0.113.10");
+
+        assertThat(resolver.resolve(request)).isEqualTo("127.0.0.1");
+    }
+}

--- a/plan/13_trusted_proxy_standardization.md
+++ b/plan/13_trusted_proxy_standardization.md
@@ -1,0 +1,21 @@
+# Trusted Proxy / Client IP 신뢰 경계 표준화 구현 계획
+
+## 수정 목적
+- X-Forwarded-For 신뢰 경계를 명확히 하고, 설정 실수(과도한 CIDR/오타)를 조기에 인지하도록 한다.
+
+## 수정할 부분
+1. ClientIpResolver 설정 파싱 안정화
+   - invalid CIDR 항목은 경고 후 제외
+2. 위험 설정 경고 추가
+   - `0.0.0.0/0`, `::/0` 사용 시 경고 로그
+   - trusted proxies 미설정 시 동작 안내 로그
+3. 단위 테스트 추가
+   - trusted proxy일 때만 XFF 신뢰
+   - untrusted proxy는 remoteAddr 사용
+   - invalid/broad CIDR 처리 검증
+4. 운영 문서 보강
+   - 로컬/단일/다중 프록시 예시 및 금지 패턴 안내
+
+## 테스트 계획
+- backend: `./gradlew test`
+- frontend: 영향 없음


### PR DESCRIPTION
## PR 작성 목적
Trusted Proxy / Client IP 신뢰 경계를 명확히 하고, 설정 실수(과도한 CIDR/오타)를 조기에 인지할 수 있도록 보강합니다.

## 원인
- X-Forwarded-For는 trusted proxy 범위가 부정확하면 spoofing에 취약해질 수 있습니다.
- invalid CIDR가 섞이면 운영자가 의도한 동작과 실제 동작이 어긋날 수 있습니다.

## 해결이 필요한 내용
- trusted proxy CIDR 파싱 안정화
- 과도한 신뢰 범위(0.0.0.0/0, ::/0) 경고
- invalid CIDR 무시 및 로그 경고
- 동작 검증 단위 테스트 추가

## 상세내용
- Backend
  - `ClientIpResolver`
    - invalid CIDR 항목은 경고 후 제외
    - broad CIDR(`0.0.0.0/0`, `::/0`) 경고 로그 추가
    - trusted proxy 미설정 시 XFF 무시 동작 안내 로그 추가
  - `ClientIpResolverTest` 신설
    - trusted proxy일 때 XFF 첫 IP 사용
    - untrusted일 때 remoteAddr 사용
    - invalid CIDR fallback 동작 검증
- Docs
  - `.env.example`에 broad CIDR 금지 권장 추가
  - `README.md`에 TRUSTED_PROXY_SUBNETS 운영 예시 추가
- Plan
  - `plan/13_trusted_proxy_standardization.md` 추가

## 예상되는 결과
- Client IP 신뢰 경계가 명확해져 오탐/오동작 위험이 줄어듭니다.
- 운영자가 설정 오류를 로그로 빠르게 인지할 수 있습니다.
- X-Forwarded-For 오남용 가능성을 낮출 수 있습니다.

## 테스트
- [x] Backend test
- [ ] Frontend test (영향 없음)
- [ ] Build (영향 없음)

실행 로그/결과:
```text
backend: ./gradlew test -> BUILD SUCCESSFUL
```

## 관련 이슈
- Closes #9

## 체크리스트
- [x] 제목이 작업 내용을 명확히 요약한다.
- [x] 본문은 목적/원인/해결/상세/결과가 분리되어 있다.
- [x] 리뷰어가 변경 범위를 빠르게 파악할 수 있다.
- [x] 불필요한 로그/설정 변경이 포함되지 않았다.
