### PR TITLE
feat(file): 대용량 업로드 무결성 검증 및 재개 상태 조회 기반 도입

### DIFF
--- a/backend/src/main/java/com/manas/backend/context/file/application/port/in/FileUploadCommand.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/in/FileUploadCommand.java
@@ -11,13 +11,15 @@ import java.util.UUID;
  * @param targetDirectory Target logical directory path (e.g., "/documents").
  * @param size            Size of the file in bytes.
  * @param userId          User ID performing the upload.
+ * @param checksumSha256  Optional expected SHA-256 checksum (hex) for integrity verification.
  */
 public record FileUploadCommand(
         InputStream content,
         String fileName,
         String targetDirectory,
         long size,
-        UUID userId
+        UUID userId,
+        String checksumSha256
 ) {
 
 }

--- a/backend/src/main/java/com/manas/backend/context/file/application/port/in/GetUploadStatusUseCase.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/in/GetUploadStatusUseCase.java
@@ -1,0 +1,5 @@
+package com.manas.backend.context.file.application.port.in;
+
+public interface GetUploadStatusUseCase {
+    UploadStatusResult getStatus(String path);
+}

--- a/backend/src/main/java/com/manas/backend/context/file/application/port/in/UploadStatusResult.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/in/UploadStatusResult.java
@@ -1,0 +1,7 @@
+package com.manas.backend.context.file.application.port.in;
+
+public record UploadStatusResult(
+        boolean exists,
+        Long size
+) {
+}

--- a/backend/src/main/java/com/manas/backend/context/file/application/port/out/FileStoragePort.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/out/FileStoragePort.java
@@ -57,6 +57,18 @@ public interface FileStoragePort {
     FileContent retrieve(String path, UUID userId);
 
     /**
+     * Returns whether the target path exists.
+     */
+    boolean exists(String path, UUID userId);
+
+    /**
+     * Returns file size in bytes for the target path.
+     *
+     * @throws IllegalArgumentException if path does not exist or is a directory.
+     */
+    long getFileSize(String path, UUID userId);
+
+    /**
      * Returns the available disk space in bytes for the storage root.
      *
      * @return Available disk space in bytes.

--- a/backend/src/main/java/com/manas/backend/context/file/application/service/UploadStatusService.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/service/UploadStatusService.java
@@ -1,0 +1,25 @@
+package com.manas.backend.context.file.application.service;
+
+import com.manas.backend.context.file.application.port.in.GetUploadStatusUseCase;
+import com.manas.backend.context.file.application.port.in.UploadStatusResult;
+import com.manas.backend.context.file.application.port.out.FileStoragePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UploadStatusService implements GetUploadStatusUseCase {
+
+    private final FileStoragePort fileStoragePort;
+
+    @Override
+    public UploadStatusResult getStatus(String path) {
+        boolean exists = fileStoragePort.exists(path, null);
+        if (!exists) {
+            return new UploadStatusResult(false, null);
+        }
+
+        long size = fileStoragePort.getFileSize(path, null);
+        return new UploadStatusResult(true, size);
+    }
+}

--- a/backend/src/main/java/com/manas/backend/context/file/infrastructure/fs/LocalFileSystemAdapter.java
+++ b/backend/src/main/java/com/manas/backend/context/file/infrastructure/fs/LocalFileSystemAdapter.java
@@ -239,6 +239,32 @@ public class LocalFileSystemAdapter implements FileStoragePort {
     }
 
     @Override
+    public boolean exists(String pathString, UUID userId) {
+        Path targetPath = resolveTarget(pathString);
+        return Files.exists(targetPath);
+    }
+
+    @Override
+    public long getFileSize(String pathString, UUID userId) {
+        Path targetPath = resolveTarget(pathString);
+
+        if (!Files.exists(targetPath)) {
+            throw new ResourceNotFoundException("File does not exist: " + targetPath);
+        }
+
+        if (Files.isDirectory(targetPath)) {
+            throw new IllegalArgumentException("Path is a directory: " + targetPath);
+        }
+
+        try {
+            return Files.size(targetPath);
+        } catch (IOException e) {
+            log.error("Failed to get file size: {}", targetPath, e);
+            throw new RuntimeException("Failed to get file size", e);
+        }
+    }
+
+    @Override
     public long getAvailableDiskSpace() {
         try {
             FileStore fileStore = Files.getFileStore(rootPath);

--- a/backend/src/main/java/com/manas/backend/context/file/infrastructure/web/dto/UploadStatusResponse.java
+++ b/backend/src/main/java/com/manas/backend/context/file/infrastructure/web/dto/UploadStatusResponse.java
@@ -1,0 +1,7 @@
+package com.manas.backend.context.file.infrastructure.web.dto;
+
+public record UploadStatusResponse(
+        boolean exists,
+        Long size
+) {
+}

--- a/backend/src/test/java/com/manas/backend/context/file/application/service/FileUploadServiceTest.java
+++ b/backend/src/test/java/com/manas/backend/context/file/application/service/FileUploadServiceTest.java
@@ -1,18 +1,22 @@
 package com.manas.backend.context.file.application.service;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.manas.backend.context.file.application.port.in.FileUploadCommand;
 import com.manas.backend.context.file.application.port.out.FileStoragePort;
+import com.manas.backend.context.file.domain.FileContent;
 import com.manas.backend.context.file.domain.FileValidator;
 import com.manas.backend.context.file.domain.event.FileUploadedEvent;
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,22 +42,18 @@ class FileUploadServiceTest {
 
     @Test
     void upload_ShouldValidateAndSaveAndPublishEvent() {
-        // Arrange
         UUID userId = UUID.randomUUID();
         String fileName = "test.txt";
         String dir = "/documents";
         long size = 100L;
         ByteArrayInputStream content = new ByteArrayInputStream(new byte[0]);
 
-        FileUploadCommand command = new FileUploadCommand(content, fileName, dir, size, userId);
+        FileUploadCommand command = new FileUploadCommand(content, fileName, dir, size, userId, null);
 
-        // Mock sufficient disk space (10GB available)
         when(fileStoragePort.getAvailableDiskSpace()).thenReturn(10L * 1024 * 1024 * 1024);
 
-        // Act
         service.upload(command);
 
-        // Assert
         verify(fileValidator).validate(fileName, size);
         verify(fileStoragePort).save(eq(content), eq("/documents/test.txt"), eq(size), eq(userId));
         verify(eventPublisher).publishEvent(any(FileUploadedEvent.class));
@@ -61,40 +61,79 @@ class FileUploadServiceTest {
 
     @Test
     void upload_ShouldFail_WhenValidationFails() {
-        // Arrange
-        FileUploadCommand command = new FileUploadCommand(null, "", "", 0, null);
+        FileUploadCommand command = new FileUploadCommand(null, "", "", 0, null, null);
         doThrow(new IllegalArgumentException("Invalid")).when(fileValidator).validate(any(), anyLong());
 
-        // Act & Assert
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () ->
-                service.upload(command)
-        );
+        assertThrows(IllegalArgumentException.class, () -> service.upload(command));
 
         verifyNoInteractions(eventPublisher);
     }
 
     @Test
     void upload_ShouldFail_WhenInsufficientDiskSpace() {
-        // Arrange
         UUID userId = UUID.randomUUID();
         String fileName = "large_file.bin";
         String dir = "/documents";
-        long size = 5L * 1024 * 1024 * 1024; // 5GB file
+        long size = 5L * 1024 * 1024 * 1024;
         ByteArrayInputStream content = new ByteArrayInputStream(new byte[0]);
 
-        FileUploadCommand command = new FileUploadCommand(content, fileName, dir, size, userId);
+        FileUploadCommand command = new FileUploadCommand(content, fileName, dir, size, userId, null);
 
-        // Mock insufficient disk space (only 1GB available)
         when(fileStoragePort.getAvailableDiskSpace()).thenReturn((long) 1024 * 1024 * 1024);
 
-        // Act & Assert
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class, () ->
-                service.upload(command)
-        );
+        assertThrows(IllegalStateException.class, () -> service.upload(command));
 
-        // Verify save was never called
         verify(fileStoragePort).getAvailableDiskSpace();
         verifyNoInteractions(eventPublisher);
     }
 
+    @Test
+    void upload_ShouldPass_WhenChecksumMatches() {
+        UUID userId = UUID.randomUUID();
+        byte[] uploaded = "hello".getBytes(StandardCharsets.UTF_8);
+        String expectedSha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
+        FileUploadCommand command = new FileUploadCommand(
+                new ByteArrayInputStream(uploaded),
+                "hello.txt",
+                "/documents",
+                uploaded.length,
+                userId,
+                expectedSha256
+        );
+
+        when(fileStoragePort.getAvailableDiskSpace()).thenReturn(10L * 1024 * 1024 * 1024);
+        when(fileStoragePort.retrieve("/documents/hello.txt", userId))
+                .thenReturn(new FileContent("hello.txt", "text/plain", uploaded.length, new ByteArrayInputStream(uploaded)));
+
+        service.upload(command);
+
+        verify(fileStoragePort).save(any(), eq("/documents/hello.txt"), eq((long) uploaded.length), eq(userId));
+        verify(fileStoragePort, never()).delete(any(), any());
+        verify(eventPublisher).publishEvent(any(FileUploadedEvent.class));
+    }
+
+    @Test
+    void upload_ShouldRollback_WhenChecksumMismatch() {
+        UUID userId = UUID.randomUUID();
+        byte[] uploaded = "hello".getBytes(StandardCharsets.UTF_8);
+
+        FileUploadCommand command = new FileUploadCommand(
+                new ByteArrayInputStream(uploaded),
+                "hello.txt",
+                "/documents",
+                uploaded.length,
+                userId,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+
+        when(fileStoragePort.getAvailableDiskSpace()).thenReturn(10L * 1024 * 1024 * 1024);
+        when(fileStoragePort.retrieve("/documents/hello.txt", userId))
+                .thenReturn(new FileContent("hello.txt", "text/plain", uploaded.length, new ByteArrayInputStream(uploaded)));
+
+        assertThrows(IllegalArgumentException.class, () -> service.upload(command));
+
+        verify(fileStoragePort).delete("/documents/hello.txt", userId);
+        verifyNoInteractions(eventPublisher);
+    }
 }

--- a/plan/14_upload_integrity_resume_foundation.md
+++ b/plan/14_upload_integrity_resume_foundation.md
@@ -1,0 +1,23 @@
+# 대용량 업로드 재개·무결성 기반 구현 계획 (#8)
+
+## 수정 목적
+- 업로드 완료 파일에 대해 SHA-256 무결성 검증을 제공한다.
+- 클라이언트 재개 전략을 위한 업로드 상태 조회 기반 API를 제공한다.
+
+## 수정할 부분
+1. `FileUploadCommand`에 `checksumSha256`(optional) 추가
+2. `FileUploadService`
+   - 저장 후 checksum 검증
+   - 불일치 시 저장 파일 롤백 삭제
+3. `FileStoragePort`/`LocalFileSystemAdapter`
+   - 파일 존재 여부/파일 크기 조회 API 추가
+4. `FileController`
+   - `checksumSha256` 업로드 파라미터 수용
+   - `GET /api/files/upload/status?path=...` 추가
+5. 테스트 보강
+   - 체크섬 일치/불일치(롤백) 테스트
+   - upload status 응답 테스트
+
+## 테스트 계획
+- backend: `./gradlew test`
+- frontend: 영향 없음


### PR DESCRIPTION
## PR 작성 목적
대용량 업로드 신뢰성을 높이기 위해, 업로드 무결성(SHA-256) 검증과 재개 전략을 위한 상태 조회 기반 API를 도입합니다.

## 원인
- 네트워크 중단/재시도 환경에서 업로드 완료 파일의 무결성을 검증하는 경로가 부족했습니다.
- 재개 로직을 위한 서버 측 파일 상태(존재/크기) 조회 인터페이스가 없어 클라이언트가 안정적으로 이어받기 전략을 세우기 어려웠습니다.

## 해결이 필요한 내용
- 업로드 완료 후 checksum 검증
- checksum 불일치 시 안전 롤백
- 업로드 상태 조회 API 제공

## 상세내용
- Upload integrity
  - `FileUploadCommand`에 `checksumSha256`(optional) 추가
  - `FileUploadService`
    - 저장 후 SHA-256 검증
    - 불일치 시 업로드 파일 삭제(rollback) 후 예외 반환
- Resume foundation
  - `GET /api/files/upload/status?path=...` 추가
  - 응답: `{ exists: boolean, size: number | null }`
  - 내부적으로 `FileStoragePort.exists/getFileSize` 확장
- Storage adapter
  - `LocalFileSystemAdapter`에 파일 존재/크기 조회 구현 추가
- Tests
  - `FileUploadServiceTest`
    - checksum 일치 시 성공
    - checksum 불일치 시 rollback 검증
  - `FileControllerTest`
    - upload status endpoint 응답 검증
- Plan
  - `plan/14_upload_integrity_resume_foundation.md` 추가

## 예상되는 결과
- 업로드 완료 파일 무결성 보장 수준이 향상됩니다.
- 클라이언트가 상태 조회 기반으로 재시도/이어받기 정책을 구현할 수 있습니다.
- 대용량 업로드 장애 상황에서 복구 가능성이 높아집니다.

## 테스트
- [x] Backend test
- [ ] Frontend test (영향 없음)
- [ ] Build (영향 없음)

실행 로그/결과:
```text
backend: ./gradlew test -> BUILD SUCCESSFUL
```

## 관련 이슈
- Closes #8

## 체크리스트
- [x] 제목이 작업 내용을 명확히 요약한다.
- [x] 본문은 목적/원인/해결/상세/결과가 분리되어 있다.
- [x] 리뷰어가 변경 범위를 빠르게 파악할 수 있다.
- [x] 불필요한 로그/설정 변경이 포함되지 않았다.
