### PR TITLE
feat(frontend): DSM 스타일 AppShell로 보호 라우트 레이아웃 통합

### DIFF
--- a/frontend/src/app/providers/RouterProvider.tsx
+++ b/frontend/src/app/providers/RouterProvider.tsx
@@ -5,6 +5,7 @@ import {LoginPage} from '@/pages/login/LoginPage';
 import {DashboardPage} from '@/pages/dashboard/DashboardPage';
 import {AdminPage} from '@/pages/admin/AdminPage';
 import {ChangePasswordPage} from '@/pages/change-password/ChangePasswordPage';
+import {AppShell} from '@/shared/ui/AppShell';
 
 // Protected Route Wrapper
 const RequireAuth: React.FC = () => {
@@ -25,6 +26,14 @@ const RequirePasswordChange: React.FC = () => {
   if (!mustChangePassword) return <Navigate to="/" replace/>;
 
   return <Outlet/>;
+};
+
+const ProtectedLayout: React.FC = () => {
+  return (
+    <AppShell>
+      <Outlet/>
+    </AppShell>
+  );
 };
 
 // Public Route Wrapper (Redirects to dashboard if already logged in)
@@ -49,8 +58,10 @@ export const AppRouter: React.FC = () => {
 
           {/* Protected Routes */}
           <Route element={<RequireAuth/>}>
-            <Route path="/" element={<DashboardPage/>}/>
-            <Route path="/admin" element={<AdminPage/>}/>
+            <Route element={<ProtectedLayout/>}>
+              <Route path="/" element={<DashboardPage/>}/>
+              <Route path="/admin" element={<AdminPage/>}/>
+            </Route>
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/pages/admin/AdminPage.tsx
+++ b/frontend/src/pages/admin/AdminPage.tsx
@@ -1,16 +1,13 @@
-import {PageLayout} from '@/shared/ui/PageLayout';
 import {AdminDashboard} from '@/features/admin-dashboard/ui/AdminDashboard';
-import {Box, Typography} from '@mui/material';
+import {Typography} from '@mui/material';
 
 export const AdminPage = () => {
   return (
-      <PageLayout title="Administration">
-        <Box sx={{p: 3}}>
-          <Typography variant="h4" component="h1" gutterBottom sx={{fontWeight: 'bold', mb: 3}}>
-            Administration
-          </Typography>
-          <AdminDashboard/>
-        </Box>
-      </PageLayout>
+    <>
+      <Typography variant="h4" component="h1" gutterBottom sx={{fontWeight: 'bold', mb: 3}}>
+        Administration
+      </Typography>
+      <AdminDashboard/>
+    </>
   );
 };

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,14 +1,6 @@
-import {PageLayout} from '@/shared/ui/PageLayout';
 import {FileBrowser} from '@/features/file-browser/ui/FileBrowser';
-import {Box} from '@mui/material';
 
 export const DashboardPage = () => {
-  return (
-      <PageLayout title="Dashboard">
-        <Box sx={{p: 3}}>
-          <FileBrowser/>
-        </Box>
-      </PageLayout>
-  );
+  return <FileBrowser/>;
 };
 

--- a/frontend/src/shared/ui/AppShell.tsx
+++ b/frontend/src/shared/ui/AppShell.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import {
+  AppBar,
+  Box,
+  Button,
+  Drawer,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Toolbar,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import {useLocation, useNavigate} from 'react-router-dom';
+import {useAuthStore} from '@/entities/user/model/store';
+
+const drawerWidth = 220;
+
+const navItems = [
+  {label: 'Files', path: '/'},
+  {label: 'Administration', path: '/admin'},
+];
+
+const getTitle = (pathname: string) => {
+  if (pathname === '/admin') return 'Administration';
+  return 'Files';
+};
+
+export const AppShell: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const [open, setOpen] = React.useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const logout = useAuthStore((s) => s.logout);
+
+  const drawer = (
+    <Box sx={{height: '100%', bgcolor: 'background.paper'}}>
+      <Toolbar>
+        <Typography variant="subtitle1" sx={{fontWeight: 700}}>Private NAS</Typography>
+      </Toolbar>
+      <List>
+        {navItems.map((item) => (
+          <ListItemButton
+            key={item.path}
+            selected={location.pathname === item.path}
+            onClick={() => {
+              navigate(item.path);
+              setOpen(false);
+            }}
+          >
+            <ListItemText primary={item.label}/>
+          </ListItemButton>
+        ))}
+      </List>
+    </Box>
+  );
+
+  return (
+    <Box sx={{display: 'flex', minHeight: '100vh', bgcolor: 'background.default'}}>
+      {isMobile ? (
+        <Drawer open={open} onClose={() => setOpen(false)}>
+          {drawer}
+        </Drawer>
+      ) : (
+        <Drawer
+          variant="permanent"
+          sx={{
+            width: drawerWidth,
+            flexShrink: 0,
+            '& .MuiDrawer-paper': {width: drawerWidth, boxSizing: 'border-box'},
+          }}
+        >
+          {drawer}
+        </Drawer>
+      )}
+
+      <Box sx={{flex: 1, minWidth: 0}}>
+        <AppBar position="sticky" color="default" elevation={0}>
+          <Toolbar>
+            {isMobile && (
+              <IconButton edge="start" sx={{mr: 1}} onClick={() => setOpen(true)}>
+                <MenuIcon/>
+              </IconButton>
+            )}
+            <Typography variant="h6" sx={{flexGrow: 1, fontWeight: 700}}>
+              {getTitle(location.pathname)}
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => {
+                logout();
+                navigate('/login', {replace: true});
+              }}
+            >
+              Logout
+            </Button>
+          </Toolbar>
+        </AppBar>
+
+        <Box sx={{p: {xs: 2, md: 3}}}>{children}</Box>
+      </Box>
+    </Box>
+  );
+};

--- a/plan/15_frontend_synology_os_ui_plan.md
+++ b/plan/15_frontend_synology_os_ui_plan.md
@@ -1,0 +1,162 @@
+# Frontend 개선 계획 - Synology DSM(OS) 레퍼런스 기반
+
+## 1) 목표
+현재 UI는 "단일 페이지 + 단순 테이블" 중심입니다. Synology DSM 스타일처럼 **데스크톱형 정보구조 + 파일 작업 중심 UX**로 재구성합니다.
+
+핵심 목표:
+- 정보구조: 상단 글로벌 바 + 좌측 사이드바 + 메인 작업영역
+- 파일작업성: 툴바/컨텍스트 메뉴/상태 패널 강화
+- 운영감시성: 시스템 상태/알림/작업 진행도 노출
+- 일관성: iOS 네이밍(예: IOSCard) 잔재를 DSM 톤으로 정리
+
+---
+
+## 2) 현재 구조 진단
+
+### 현재 강점
+- React Query + Zustand 기반 상태 구조는 확장 가능
+- 파일 브라우저/관리 페이지 라우팅은 이미 분리되어 있음
+- 테마가 이미 "DSM-inspired"로 시작점 보유
+
+### 현재 한계 (Synology 대비)
+1. **레이아웃 계층 부족**
+   - `PageLayout`이 상단바만 제공, 좌측 네비/작업 패널 부재
+2. **파일 작업 흐름 단순**
+   - 파일 선택/이동은 가능하지만, 컨텍스트 메뉴·우측 정보패널·작업 큐가 없음
+3. **관측 UI 약함**
+   - 업로드/다운로드 진행 상태를 전역에서 확인하기 어려움
+4. **컴포넌트 네이밍 불일치**
+   - DSM 방향인데 `IOS*` 명명 혼재
+
+---
+
+## 3) 변경 범위 (우선순위)
+
+## P1. Shell 구조 전환 (가장 먼저)
+### 변경
+- `PageLayout`을 **AppShell**로 확장
+  - TopBar: 현재 사용자, 빠른 액션, 알림 버튼
+  - Left Sidebar: Files, Admin, System, Audit 네비
+  - Main Content: 현재 라우트 콘텐츠
+
+### 대상 파일
+- `frontend/src/shared/ui/PageLayout.tsx` (대개편 또는 `AppShell.tsx` 신설)
+- `frontend/src/pages/dashboard/DashboardPage.tsx`
+- `frontend/src/pages/admin/AdminPage.tsx`
+- `frontend/src/app/providers/RouterProvider.tsx` (레이아웃 라우트 적용)
+
+### 완료 기준
+- 로그인 후 모든 보호 라우트가 동일 Shell 안에서 렌더링
+- 모바일에서는 사이드바가 Drawer로 축약
+
+---
+
+## P1. 파일 브라우저 UX 정렬 (DSM File Station 유사)
+### 변경
+- 파일 헤더를 "타이틀"에서 **작업 툴바 중심**으로 변경
+  - 업로드/새폴더/이동/삭제/새로고침
+- 선택 상태 바(선택 n개) + 대량 작업 진입점 강화
+- Breadcrumb + 검색 + 정렬/필터 바 추가
+
+### 대상 파일
+- `frontend/src/features/file-browser/ui/FileBrowser.tsx`
+- `frontend/src/features/file-actions/ui/FileActionsToolbar.tsx`
+- `frontend/src/widgets/file-table/ui/FileTable.tsx`
+
+### 완료 기준
+- 파일 선택 후 가능한 작업이 항상 상단에서 명확히 노출
+- list/grid 전환 시 선택 상태 일관 유지
+
+---
+
+## P2. 우측 상세 패널 + 컨텍스트 메뉴
+### 변경
+- 선택 파일 메타데이터(크기, 수정일, 소유자, 경로) 패널 추가
+- 우클릭 컨텍스트 메뉴(열기/다운로드/이동/삭제/정보)
+
+### 대상 파일
+- `frontend/src/widgets/file-table/ui/FileTable.tsx`
+- `frontend/src/features/file-browser/ui/FileBrowser.tsx`
+- `frontend/src/entities/file/model/types.ts` (필요 시 상세 필드 확장)
+
+### 완료 기준
+- 마우스 우클릭으로 핵심 액션 실행 가능
+- 단일/다중 선택별 메뉴 활성화 규칙 일관
+
+---
+
+## P2. 업로드/작업 센터 (Task Center Lite)
+### 변경
+- 전역 작업 상태 스토어 신설 (업로드/이동/삭제 진행도)
+- TopBar에서 작업 수/실패 건수 확인
+- 토스트 외에 "작업 패널" 제공
+
+### 대상 파일
+- `frontend/src/shared/model/` 하위 작업 스토어 신설
+- `frontend/src/shared/ui/NotificationSnackbar.tsx` (역할 분리)
+- `frontend/src/shared/ui/` 하위 TaskCenter 컴포넌트 신설
+
+### 완료 기준
+- 긴 작업이 토스트 사라진 뒤에도 추적 가능
+- 실패 작업 재시도 액션 제공
+
+---
+
+## P3. 디자인 시스템 정리 (네이밍/토큰)
+### 변경
+- `IOSCard`, `IOSButton`, `IOSInput`, `IOSBreadcrumbs` → DSM 중립 네이밍으로 리팩터
+  - 예: `AppCard`, `AppButton`, `AppInput`, `AppBreadcrumbs`
+- 테마 토큰 정리 (간격, border, hover, selected, panel background)
+
+### 대상 파일
+- `frontend/src/shared/ui/*`
+- `frontend/src/app/providers/ThemeProvider.tsx`
+- 사용처 전체 import 업데이트
+
+### 완료 기준
+- 도메인/브랜드와 맞는 일관된 네이밍
+- 컴포넌트 외형이 동일 토큰 기반으로 동작
+
+---
+
+## 4) 구현 순서 (권장)
+1. Shell(AppShell) 구축 + 라우팅 통합
+2. FileBrowser 상단 작업바/정렬·검색/선택 UX 개선
+3. 상세 패널 + 컨텍스트 메뉴
+4. Task Center Lite
+5. 네이밍/디자인 토큰 리팩터
+
+---
+
+## 5) 테스트 계획
+
+### 단위/컴포넌트
+- FileTable 선택/우클릭/뷰전환 회귀 테스트
+- FileBrowser 툴바 액션 노출 조건 테스트
+- TaskCenter 상태 표시 테스트
+
+### E2E(권장)
+- 로그인 → 파일 선택 → 이동/삭제 → 알림/작업상태 확인
+- 업로드 실패 후 상태 패널에서 실패 원인/재시도 확인
+
+### 성능 체크
+- 대량 파일 목록(1k+) 렌더링 시 프레임 드랍 여부 확인
+- 필요 시 리스트 가상화(react-window) 도입 검토
+
+---
+
+## 6) 리스크 및 대응
+- 리스크: 대규모 UI 변경으로 회귀 가능성 증가
+- 대응: 단계별 PR 분리 (Shell / File UX / TaskCenter / 리팩터)
+
+- 리스크: 백엔드 API 부족으로 UX 완성도 제한
+- 대응: 프론트 우선 상태 모델 설계 후 필요한 API를 별도 이슈로 역제안
+
+---
+
+## 7) 이번 작업에서 바로 시작할 PR 단위 제안
+- PR-A (P1): AppShell + 라우팅 통합
+- PR-B (P1): FileBrowser 툴바/검색/정렬 개선
+- PR-C (P2): 상세 패널 + 컨텍스트 메뉴
+- PR-D (P2): Task Center Lite
+- PR-E (P3): UI 컴포넌트 네이밍 정리

--- a/plan/16_frontend_p1_appshell_implementation.md
+++ b/plan/16_frontend_p1_appshell_implementation.md
@@ -1,0 +1,18 @@
+# #15 구현 계획 - DSM 스타일 AppShell 및 라우트 레이아웃 통합
+
+## 수정 목적
+- 로그인 후 보호 라우트를 하나의 AppShell(TopBar + Sidebar + Content) 안에서 일관되게 제공한다.
+
+## 수정할 부분
+1. `AppShell` 신설
+   - Desktop: 고정 Sidebar + TopBar
+   - Mobile: Drawer Sidebar
+2. `RouterProvider` 레이아웃 라우트 적용
+   - `RequireAuth` 아래 `ProtectedLayout(AppShell + Outlet)` 도입
+3. 페이지 단 단순화
+   - Dashboard/Admin에서 기존 `PageLayout` 래핑 제거
+
+## 테스트 계획
+- frontend: `npx vitest run`
+- frontend: `npm run build`
+- 수동: 로그인 후 `/`, `/admin` 이동 시 동일 Shell 유지 확인


### PR DESCRIPTION
## PR 작성 목적
Synology DSM 스타일의 공통 AppShell(TopBar + Sidebar + Content)을 도입해 보호 라우트의 레이아웃 일관성을 확보합니다.

## 원인
기존 구조는 페이지별 `PageLayout` 기반으로 중복이 많고, DSM형 데스크톱 UX 확장(작업센터/알림/전역액션) 기반이 약했습니다.

## 해결이 필요한 내용
- AppShell 컴포넌트 도입
- 보호 라우트 Layout Route 통합
- Dashboard/Admin의 중복 레이아웃 제거

## 상세내용
- `frontend/src/shared/ui/AppShell.tsx` 신설
  - Desktop: 고정 Sidebar
  - Mobile: Drawer Sidebar
  - TopBar 타이틀/로그아웃 액션 포함
- `RouterProvider`
  - `RequireAuth` 하위에 `ProtectedLayout(AppShell + Outlet)` 적용
- `DashboardPage`, `AdminPage`
  - 기존 `PageLayout` 래핑 제거 후 Shell 내부 컨텐츠로 단순화
- Plan 문서
  - `plan/15_frontend_synology_os_ui_plan.md`
  - `plan/16_frontend_p1_appshell_implementation.md`

## 예상되는 결과
- 로그인 후 `/`, `/admin`가 동일한 Shell 경험으로 통일됩니다.
- 후속 P1/P2(파일 툴바, Task Center, 상세 패널) 확장 기반이 마련됩니다.

## 테스트
- [x] Frontend test
- [x] Build

실행 로그/결과:
```text
frontend: npx vitest run -> 4 passed / 10 passed
frontend: npm run build -> success
```

## 관련 이슈
- Closes #15

## 체크리스트
- [x] 제목이 작업 내용을 명확히 요약한다.
- [x] 본문은 목적/원인/해결/상세/결과가 분리되어 있다.
- [x] 리뷰어가 변경 범위를 빠르게 파악할 수 있다.
- [x] 불필요한 동작 변경이 포함되지 않았다.
