### PR TITLE
refactor(frontend): 공용 UI 네이밍을 App* 컨벤션으로 정리

### DIFF
--- a/frontend/src/features/auth/ui/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/LoginForm.tsx
@@ -4,7 +4,7 @@ import {useNavigate} from 'react-router-dom';
 import {AxiosError} from 'axios';
 import {apiClient} from '@/shared/api/axios';
 import {useAuthStore} from '@/entities/user/model/store';
-import {IOSButton, IOSInput} from '@/shared/ui';
+import {AppButton, AppInput} from '@/shared/ui';
 
 export const LoginForm: React.FC = () => {
   const [username, setUsername] = useState('');
@@ -42,7 +42,7 @@ export const LoginForm: React.FC = () => {
             </Alert>
         )}
 
-        <IOSInput
+        <AppInput
             margin="normal"
             required
             fullWidth
@@ -54,7 +54,7 @@ export const LoginForm: React.FC = () => {
             value={username}
             onChange={(e) => setUsername(e.target.value)}
         />
-        <IOSInput
+        <AppInput
             margin="normal"
             required
             fullWidth
@@ -66,9 +66,9 @@ export const LoginForm: React.FC = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
         />
-        <IOSButton type="submit" fullWidth variant="contained" sx={{mt: 4, mb: 2}} size="large">
+        <AppButton type="submit" fullWidth variant="contained" sx={{mt: 4, mb: 2}} size="large">
           Sign In
-        </IOSButton>
+        </AppButton>
       </Box>
   );
 };

--- a/frontend/src/features/file-actions/ui/FileActionsToolbar.tsx
+++ b/frontend/src/features/file-actions/ui/FileActionsToolbar.tsx
@@ -5,7 +5,7 @@ import UploadFileIcon from '@mui/icons-material/UploadFile';
 import DriveFileMoveIcon from '@mui/icons-material/DriveFileMove';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import {useFileActions} from '../model/useFileActions';
-import {IOSButton} from '@/shared/ui';
+import {AppButton} from '@/shared/ui';
 import {MoveFileModal} from './MoveFileModal';
 
 interface FileActionsToolbarProps {
@@ -93,14 +93,14 @@ export const FileActionsToolbar: React.FC<FileActionsToolbarProps> = ({
               </IconButton>
             </Tooltip>
         ) : (
-        <IOSButton
+        <AppButton
             variant="contained"
             startIcon={<UploadFileIcon/>}
             onClick={handleUploadClick}
             disabled={isUploading}
         >
           Upload
-        </IOSButton>
+        </AppButton>
         )}
 
         {selectedFiles.size > 0 && (

--- a/frontend/src/features/file-actions/ui/folder-picker/FolderPicker.tsx
+++ b/frontend/src/features/file-actions/ui/folder-picker/FolderPicker.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material';
 import FolderIcon from '@mui/icons-material/Folder';
 import {useFiles} from '@/entities/file/model/useFiles';
-import {IOSBreadcrumbs} from '@/shared/ui/IOSBreadcrumbs';
+import {AppBreadcrumbs} from '@/shared/ui/AppBreadcrumbs';
 
 interface FolderPickerProps {
   currentPath: string;
@@ -38,7 +38,7 @@ export const FolderPicker: React.FC<FolderPickerProps> = ({currentPath, onNaviga
   return (
       <Box sx={{minHeight: '300px'}}>
         <Box sx={{mb: 1}}>
-          <IOSBreadcrumbs breadcrumbs={data.breadcrumbs} onNavigate={onNavigate}/>
+          <AppBreadcrumbs breadcrumbs={data.breadcrumbs} onNavigate={onNavigate}/>
         </Box>
 
         {folders.length === 0 ? (

--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -20,7 +20,7 @@ import {
 import ViewListIcon from '@mui/icons-material/ViewList';
 import GridViewIcon from '@mui/icons-material/GridView';
 import SearchIcon from '@mui/icons-material/Search';
-import {IOSBreadcrumbs} from '@/shared/ui/IOSBreadcrumbs';
+import {AppBreadcrumbs} from '@/shared/ui/AppBreadcrumbs';
 import {FileTable} from '@/widgets/file-table/ui/FileTable';
 import {useFileBrowser} from '../model/useFileBrowser';
 import {FileActionsToolbar} from '@/features/file-actions/ui/FileActionsToolbar';
@@ -131,7 +131,7 @@ export const FileBrowser: React.FC = () => {
 
         {data && (
             <Box mb={2}>
-              <IOSBreadcrumbs breadcrumbs={data.breadcrumbs} onNavigate={navigateTo}/>
+              <AppBreadcrumbs breadcrumbs={data.breadcrumbs} onNavigate={navigateTo}/>
             </Box>
         )}
 

--- a/frontend/src/pages/change-password/ChangePasswordPage.tsx
+++ b/frontend/src/pages/change-password/ChangePasswordPage.tsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import {Alert, Box, Card, CardContent, Typography} from '@mui/material';
 import {AxiosError} from 'axios';
 import {apiClient} from '@/shared/api/axios';
-import {IOSButton, IOSInput} from '@/shared/ui';
+import {AppButton, AppInput} from '@/shared/ui';
 import {useAuthStore} from '@/entities/user/model/store';
 import {useNavigate} from 'react-router-dom';
 
@@ -59,7 +59,7 @@ export const ChangePasswordPage: React.FC = () => {
           {success && <Alert severity="success" sx={{mb: 2}}>{success}</Alert>}
 
           <Box component="form" onSubmit={handleSubmit}>
-            <IOSInput
+            <AppInput
               fullWidth
               margin="normal"
               label="Current Password"
@@ -68,7 +68,7 @@ export const ChangePasswordPage: React.FC = () => {
               onChange={(e) => setCurrentPassword(e.target.value)}
               required
             />
-            <IOSInput
+            <AppInput
               fullWidth
               margin="normal"
               label="New Password"
@@ -77,7 +77,7 @@ export const ChangePasswordPage: React.FC = () => {
               onChange={(e) => setNewPassword(e.target.value)}
               required
             />
-            <IOSInput
+            <AppInput
               fullWidth
               margin="normal"
               label="Confirm New Password"
@@ -87,10 +87,10 @@ export const ChangePasswordPage: React.FC = () => {
               required
             />
 
-            <IOSButton fullWidth type="submit" variant="contained" sx={{mt: 2}}>Update Password</IOSButton>
-            <IOSButton fullWidth type="button" variant="text" sx={{mt: 1}} onClick={handleLogout}>
+            <AppButton fullWidth type="submit" variant="contained" sx={{mt: 2}}>Update Password</AppButton>
+            <AppButton fullWidth type="button" variant="text" sx={{mt: 1}} onClick={handleLogout}>
               Logout
-            </IOSButton>
+            </AppButton>
           </Box>
         </CardContent>
       </Card>

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Box, Typography, useMediaQuery, useTheme} from '@mui/material';
 import {LoginForm} from '@/features/auth/ui/LoginForm';
-import {IOSCard} from '@/shared/ui';
+import {AppCard} from '@/shared/ui';
 
 export const LoginPage: React.FC = () => {
   const theme = useTheme();
@@ -28,7 +28,7 @@ export const LoginPage: React.FC = () => {
             p: isMobile ? 0 : 2,
           }}
       >
-        <IOSCard
+        <AppCard
             sx={{
               width: '100%',
 
@@ -64,7 +64,7 @@ export const LoginPage: React.FC = () => {
           </Typography>
 
           <LoginForm/>
-        </IOSCard>
+        </AppCard>
       </Box>
   );
 };

--- a/frontend/src/shared/ui/AppBreadcrumbs.tsx
+++ b/frontend/src/shared/ui/AppBreadcrumbs.tsx
@@ -1,0 +1,3 @@
+import {IOSBreadcrumbs} from './IOSBreadcrumbs';
+
+export const AppBreadcrumbs = IOSBreadcrumbs;

--- a/frontend/src/shared/ui/AppButton.tsx
+++ b/frontend/src/shared/ui/AppButton.tsx
@@ -1,0 +1,3 @@
+import {IOSButton} from './IOSButton';
+
+export const AppButton = IOSButton;

--- a/frontend/src/shared/ui/AppCard.tsx
+++ b/frontend/src/shared/ui/AppCard.tsx
@@ -1,0 +1,3 @@
+import {IOSCard} from './IOSCard';
+
+export const AppCard = IOSCard;

--- a/frontend/src/shared/ui/AppInput.tsx
+++ b/frontend/src/shared/ui/AppInput.tsx
@@ -1,0 +1,3 @@
+import {IOSInput} from './IOSInput';
+
+export const AppInput = IOSInput;

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -1,5 +1,11 @@
+export * from './AppButton';
+export * from './AppInput';
+export * from './AppCard';
+export * from './AppBreadcrumbs';
+export * from './PageLayout';
+
+// Legacy aliases (temporary)
 export * from './IOSButton';
 export * from './IOSInput';
 export * from './IOSCard';
-export * from './PageLayout';
 export * from './IOSBreadcrumbs';

--- a/frontend/src/widgets/audit-log-table/ui/AuditLogTable.tsx
+++ b/frontend/src/widgets/audit-log-table/ui/AuditLogTable.tsx
@@ -10,7 +10,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import {IOSCard} from '@/shared/ui';
+import {AppCard} from '@/shared/ui';
 import type {AuditLog} from '@/entities/audit/model/types';
 
 interface AuditLogTableProps {
@@ -30,7 +30,7 @@ const getStatusColor = (status: string) => {
 
 export const AuditLogTable: React.FC<AuditLogTableProps> = ({logs}) => {
   return (
-      <IOSCard sx={{p: 0, overflow: 'hidden'}}>
+      <AppCard sx={{p: 0, overflow: 'hidden'}}>
         <Box sx={{p: 2, borderBottom: 1, borderColor: 'divider'}}>
           <Typography variant="h6" fontWeight={600}>Audit Logs</Typography>
         </Box>
@@ -74,6 +74,6 @@ export const AuditLogTable: React.FC<AuditLogTableProps> = ({logs}) => {
             </TableBody>
           </Table>
         </TableContainer>
-      </IOSCard>
+      </AppCard>
   );
 };

--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -19,7 +19,7 @@ import {
   useTheme,
 } from '@mui/material';
 import type {FileNode} from '@/entities/file/model/types';
-import {IOSCard} from '@/shared/ui';
+import {AppCard} from '@/shared/ui';
 import {FileIcon} from '@/entities/file/ui/FileIcon';
 
 export type ViewMode = 'list' | 'grid';
@@ -126,7 +126,7 @@ export const FileTable: React.FC<FileTableProps> = ({
   // Mobile View: Always List (Simplified, selection via long press? Or just checkbox)
   if (isMobile) {
     return (
-        <IOSCard sx={{p: 0, overflow: 'hidden'}}>
+        <AppCard sx={{p: 0, overflow: 'hidden'}}>
           <List disablePadding>
             {files.map((file, index) => (
                 <ListItem
@@ -169,7 +169,7 @@ export const FileTable: React.FC<FileTableProps> = ({
                 </ListItem>
             ))}
           </List>
-        </IOSCard>
+        </AppCard>
     );
   }
 
@@ -239,7 +239,7 @@ export const FileTable: React.FC<FileTableProps> = ({
 
   // Desktop View: Table (List)
   return (
-      <TableContainer component={IOSCard} sx={{overflow: 'hidden'}}>
+      <TableContainer component={AppCard} sx={{overflow: 'hidden'}}>
         <Table sx={{minWidth: 650}} aria-label="file table">
           <TableHead>
             <TableRow>

--- a/frontend/src/widgets/system-health/ui/SystemHealthWidget.tsx
+++ b/frontend/src/widgets/system-health/ui/SystemHealthWidget.tsx
@@ -3,7 +3,7 @@ import {Box, CircularProgress, Stack, Typography} from '@mui/material';
 import MemoryIcon from '@mui/icons-material/Memory';
 import StorageIcon from '@mui/icons-material/Storage';
 import SpeedIcon from '@mui/icons-material/Speed';
-import {IOSCard} from '@/shared/ui';
+import {AppCard} from '@/shared/ui';
 import type {SystemHealth} from '@/entities/system/model/types';
 
 interface SystemHealthWidgetProps {
@@ -25,7 +25,7 @@ const StatCard = ({title, value, icon, subValue}: {
   subValue?: string;
   icon: React.ReactNode
 }) => (
-    <IOSCard sx={{p: 3, height: '100%'}}>
+    <AppCard sx={{p: 3, height: '100%'}}>
       <Box sx={{display: 'flex', alignItems: 'center', mb: 2}}>
         <Box sx={{
           p: 1,
@@ -48,7 +48,7 @@ const StatCard = ({title, value, icon, subValue}: {
             {subValue}
           </Typography>
       )}
-    </IOSCard>
+    </AppCard>
 );
 
 export const SystemHealthWidget: React.FC<SystemHealthWidgetProps> = ({data, isLoading}) => {

--- a/frontend/src/widgets/user-table/ui/UserTable.tsx
+++ b/frontend/src/widgets/user-table/ui/UserTable.tsx
@@ -10,7 +10,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import {IOSButton, IOSCard} from '@/shared/ui';
+import {AppButton, AppCard} from '@/shared/ui';
 import type {UserSummary} from '@/entities/user/model/types';
 import AddIcon from '@mui/icons-material/Add';
 
@@ -21,7 +21,7 @@ interface UserTableProps {
 
 export const UserTable: React.FC<UserTableProps> = ({users, onAddUser}) => {
   return (
-      <IOSCard sx={{p: 0, overflow: 'hidden'}}>
+      <AppCard sx={{p: 0, overflow: 'hidden'}}>
         <Box sx={{
           p: 2,
           display: 'flex',
@@ -31,14 +31,14 @@ export const UserTable: React.FC<UserTableProps> = ({users, onAddUser}) => {
           borderColor: 'divider'
         }}>
           <Typography variant="h6" fontWeight={600}>Users</Typography>
-          <IOSButton
+          <AppButton
               startIcon={<AddIcon/>}
               size="small"
               variant="contained"
               onClick={onAddUser}
           >
             Add User
-          </IOSButton>
+          </AppButton>
         </Box>
         <TableContainer>
           <Table>
@@ -69,6 +69,6 @@ export const UserTable: React.FC<UserTableProps> = ({users, onAddUser}) => {
             </TableBody>
           </Table>
         </TableContainer>
-      </IOSCard>
+      </AppCard>
   );
 };

--- a/plan/20_frontend_p3_ui_naming_cleanup.md
+++ b/plan/20_frontend_p3_ui_naming_cleanup.md
@@ -1,0 +1,14 @@
+# #19 구현 계획 - UI 네이밍 정리(iOS 잔재 제거)
+
+## 수정 목적
+- DSM 지향 UI 컨벤션에 맞춰 공용 UI 컴포넌트 네이밍을 중립화(`App*`)한다.
+
+## 수정할 부분
+1. `AppButton/AppInput/AppCard/AppBreadcrumbs` 컴포넌트 추가
+2. 앱 전역 사용처 import/컴포넌트명을 `IOS*` -> `App*`로 전환
+3. `shared/ui/index.ts`에서 `App*`를 기본 export로 노출
+4. 기존 `IOS*`는 임시 호환 alias로 유지
+
+## 테스트 계획
+- frontend: `npx vitest run`
+- frontend: `npm run build`


### PR DESCRIPTION
## PR 작성 목적
DSM 지향 UI 컨벤션 정합성을 위해 공용 UI 컴포넌트 네이밍을 `IOS*`에서 `App*`로 정리합니다.

## 원인
`IOS*` 명명은 현재 제품 방향과 맞지 않아 코드 이해/확장 시 혼선을 유발할 수 있습니다.

## 해결이 필요한 내용
- 공용 컴포넌트 네이밍 중립화
- 전역 사용처 import/호출명 정리
- 하위 호환성 유지

## 상세내용
- 신규 컴포넌트 추가
  - `AppButton`, `AppInput`, `AppCard`, `AppBreadcrumbs`
- 사용처 전환
  - 로그인/비밀번호변경/파일브라우저/파일테이블/시스템위젯/유저테이블 등 `App*`로 교체
- `shared/ui/index.ts`
  - `App*` 우선 export
  - 기존 `IOS*`는 레거시 alias로 임시 유지
- Plan
  - `plan/20_frontend_p3_ui_naming_cleanup.md` 추가

## 예상되는 결과
- 코드베이스 네이밍이 제품 방향과 일치합니다.
- 후속 디자인 시스템 리팩터 작업의 가독성과 일관성이 향상됩니다.

## 테스트
- [x] Frontend test
- [x] Build

실행 로그/결과:
```text
frontend: npx vitest run -> 4 passed / 10 passed
frontend: npm run build -> success
```

## 관련 이슈
- Closes #19

## 체크리스트
- [x] 제목이 작업 내용을 명확히 요약한다.
- [x] 본문은 목적/원인/해결/상세/결과가 분리되어 있다.
- [x] 리뷰어가 변경 범위를 빠르게 파악할 수 있다.
- [x] 불필요한 동작 변경이 포함되지 않았다.
