### PR TITLE
refactor(backend): 파일 작업 예외 표준화 및 전역 매핑 강화

### DIFF
--- a/backend/src/main/java/com/manas/backend/common/exception/FileOperationException.java
+++ b/backend/src/main/java/com/manas/backend/common/exception/FileOperationException.java
@@ -1,0 +1,11 @@
+package com.manas.backend.common.exception;
+
+public class FileOperationException extends RuntimeException {
+    public FileOperationException(String message) {
+        super(message);
+    }
+
+    public FileOperationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/manas/backend/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/manas/backend/common/exception/GlobalExceptionHandler.java
@@ -40,6 +40,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return problemDetail;
     }
 
+    @ExceptionHandler(FileOperationException.class)
+    ProblemDetail handleFileOperationException(FileOperationException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        problemDetail.setTitle("File Operation Failed");
+        problemDetail.setType(URI.create("https://manas.com/errors/file-operation-failed"));
+        problemDetail.setProperty(DEFAULT_TIMESTAMP, Instant.now());
+        return problemDetail;
+    }
+
     @ExceptionHandler(Exception.class)
     ProblemDetail handleGenericException(Exception e) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred.");

--- a/backend/src/main/java/com/manas/backend/context/file/application/service/DeleteFilesService.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/service/DeleteFilesService.java
@@ -28,7 +28,7 @@ public class DeleteFilesService implements DeleteFilesUseCase {
             try {
                 fileStoragePort.delete(path, userId);
                 recordAuditLogUseCase.record(userId, "DELETE_FILE", path, "N/A", "SUCCESS");
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 log.error("Failed to delete file: {}", path, e);
                 recordAuditLogUseCase.record(userId, "DELETE_FILE", path, "N/A", "FAILURE");
                 // We choose to continue deleting others, or throw?

--- a/backend/src/main/java/com/manas/backend/context/file/application/service/FileUploadService.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/service/FileUploadService.java
@@ -1,5 +1,6 @@
 package com.manas.backend.context.file.application.service;
 
+import com.manas.backend.common.exception.FileOperationException;
 import com.manas.backend.context.file.application.port.in.FileUploadCommand;
 import com.manas.backend.context.file.application.port.in.FileUploadUseCase;
 import com.manas.backend.context.file.application.port.out.FileStoragePort;
@@ -95,7 +96,7 @@ public class FileUploadService implements FileUploadUseCase {
                 }
             }
         } catch (IOException e) {
-            throw new RuntimeException("Failed to verify uploaded file checksum", e);
+            throw new FileOperationException("Failed to verify uploaded file checksum", e);
         }
     }
 

--- a/backend/src/main/java/com/manas/backend/context/file/application/service/MoveFileService.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/service/MoveFileService.java
@@ -23,7 +23,7 @@ public class MoveFileService implements MoveFileUseCase {
         try {
             fileStoragePort.move(sourcePath, destinationPath, userId);
             recordAuditLogUseCase.record(userId, "MOVE_FILE", targetInfo, "N/A", "SUCCESS");
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to move file: {}", targetInfo, e);
             recordAuditLogUseCase.record(userId, "MOVE_FILE", targetInfo, "N/A", "FAILURE");
             throw e;

--- a/backend/src/main/java/com/manas/backend/context/file/application/service/PreviewService.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/service/PreviewService.java
@@ -1,5 +1,6 @@
 package com.manas.backend.context.file.application.service;
 
+import com.manas.backend.common.exception.FileOperationException;
 import com.manas.backend.context.file.application.port.in.GetFilePreviewUseCase;
 import com.manas.backend.context.file.application.port.out.FileStoragePort;
 import com.manas.backend.context.file.application.port.out.PreviewGeneratorPort;
@@ -42,7 +43,7 @@ public class PreviewService implements GetFilePreviewUseCase {
                 Files.createDirectories(cacheDir);
             }
         } catch (IOException e) {
-            throw new RuntimeException("Failed to initialize cache directory: " + cacheDir, e);
+            throw new FileOperationException("Failed to initialize cache directory: " + cacheDir, e);
         }
     }
 
@@ -124,7 +125,7 @@ public class PreviewService implements GetFilePreviewUseCase {
             byte[] hash = digest.digest(path.getBytes());
             return HexFormat.of().formatHex(hash);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-256 algorithm not found", e);
+            throw new FileOperationException("SHA-256 algorithm not found", e);
         }
     }
 

--- a/backend/src/main/java/com/manas/backend/context/file/infrastructure/fs/LocalFileSystemAdapter.java
+++ b/backend/src/main/java/com/manas/backend/context/file/infrastructure/fs/LocalFileSystemAdapter.java
@@ -1,5 +1,6 @@
 package com.manas.backend.context.file.infrastructure.fs;
 
+import com.manas.backend.common.exception.FileOperationException;
 import com.manas.backend.common.exception.ResourceNotFoundException;
 import com.manas.backend.context.file.application.port.out.FileStoragePort;
 import com.manas.backend.context.file.domain.DirectoryListing;
@@ -48,7 +49,7 @@ public class LocalFileSystemAdapter implements FileStoragePort {
             log.info("User {} deleted file: {}", userId, targetPath);
         } catch (IOException e) {
             log.error("Failed to delete path: {}", targetPath, e);
-            throw new RuntimeException("Failed to delete file: " + e.getMessage(), e);
+            throw new FileOperationException("Failed to delete file: " + e.getMessage(), e);
         }
     }
 
@@ -73,7 +74,7 @@ public class LocalFileSystemAdapter implements FileStoragePort {
             log.info("User {} moved file from {} to {}", userId, sourcePath, destinationPath);
         } catch (IOException e) {
             log.error("Failed to move file from {} to {}", sourcePath, destinationPath, e);
-            throw new RuntimeException("Failed to move file: " + e.getMessage(), e);
+            throw new FileOperationException("Failed to move file: " + e.getMessage(), e);
         }
     }
 
@@ -91,7 +92,7 @@ public class LocalFileSystemAdapter implements FileStoragePort {
             log.info("User {} uploaded file: {} (Size: {})", userId, targetPath, size);
         } catch (IOException e) {
             log.error("Failed to upload file to: {}", targetPath, e);
-            throw new RuntimeException("Failed to upload file", e);
+            throw new FileOperationException("Failed to upload file", e);
         }
     }
 
@@ -121,7 +122,7 @@ public class LocalFileSystemAdapter implements FileStoragePort {
             return new FileContent(fileName, contentType, size, inputStream);
         } catch (IOException e) {
             log.error("Failed to retrieve file: {}", targetPath, e);
-            throw new RuntimeException("Failed to retrieve file content", e);
+            throw new FileOperationException("Failed to retrieve file content", e);
         }
     }
 
@@ -187,7 +188,7 @@ public class LocalFileSystemAdapter implements FileStoragePort {
                     .toList();
         } catch (IOException e) {
             log.error("Failed to list directory: {}", directory, e);
-            throw new RuntimeException("Failed to list directory content", e);
+            throw new FileOperationException("Failed to list directory content", e);
         }
     }
 
@@ -260,7 +261,7 @@ public class LocalFileSystemAdapter implements FileStoragePort {
             return Files.size(targetPath);
         } catch (IOException e) {
             log.error("Failed to get file size: {}", targetPath, e);
-            throw new RuntimeException("Failed to get file size", e);
+            throw new FileOperationException("Failed to get file size", e);
         }
     }
 
@@ -271,7 +272,7 @@ public class LocalFileSystemAdapter implements FileStoragePort {
             return fileStore.getUsableSpace();
         } catch (IOException e) {
             log.error("Failed to get available disk space for root path: {}", rootPath, e);
-            throw new RuntimeException("Failed to check disk space", e);
+            throw new FileOperationException("Failed to check disk space", e);
         }
     }
 }

--- a/backend/src/main/java/com/manas/backend/context/file/infrastructure/image/ThumbnailatorAdapter.java
+++ b/backend/src/main/java/com/manas/backend/context/file/infrastructure/image/ThumbnailatorAdapter.java
@@ -1,5 +1,6 @@
 package com.manas.backend.context.file.infrastructure.image;
 
+import com.manas.backend.common.exception.FileOperationException;
 import com.manas.backend.context.file.application.port.out.PreviewGeneratorPort;
 import com.manas.backend.context.file.domain.FileContent;
 import com.manas.backend.context.file.domain.PreviewType;
@@ -48,7 +49,7 @@ public class ThumbnailatorAdapter implements PreviewGeneratorPort {
 
         } catch (IOException e) {
             log.error("Failed to generate thumbnail for {}", source.fileName(), e);
-            throw new RuntimeException("Thumbnail generation failed", e);
+            throw new FileOperationException("Thumbnail generation failed", e);
         }
     }
 

--- a/plan/21_backend_p1_exception_standardization.md
+++ b/plan/21_backend_p1_exception_standardization.md
@@ -1,0 +1,13 @@
+# #25 구현 계획 - 예외 처리 표준화 및 RuntimeException 축소
+
+## 수정 목적
+- 파일/미리보기 계층 예외를 표준화해 API 응답 일관성과 장애 분석성을 개선한다.
+
+## 수정할 부분
+1. `FileOperationException` 신설
+2. `GlobalExceptionHandler`에 파일 작업 예외 핸들러 추가
+3. `LocalFileSystemAdapter`, `PreviewService`, `ThumbnailatorAdapter`, `FileUploadService`에서 포괄 RuntimeException 축소
+4. 서비스 계층 broad catch(`Exception`)를 `RuntimeException` 중심으로 축소
+
+## 테스트 계획
+- backend: `./gradlew test`


### PR DESCRIPTION
## PR 작성 목적
파일 관련 예외 처리 표준화를 통해 API 응답 일관성과 장애 분석성을 개선합니다.

## 원인
파일/미리보기 계층에서 `RuntimeException` 및 broad catch가 혼재되어 예외 의미가 불명확했습니다.

## 해결이 필요한 내용
- 파일 작업 전용 예외 타입 도입
- 전역 예외 핸들러 매핑 추가
- broad catch 축소

## 상세내용
- `FileOperationException` 신설
- `GlobalExceptionHandler`에 `FileOperationException` 처리 추가
- `LocalFileSystemAdapter`, `PreviewService`, `ThumbnailatorAdapter`, `FileUploadService`의 포괄 RuntimeException을 `FileOperationException`으로 치환
- `DeleteFilesService`, `MoveFileService` catch를 `Exception` -> `RuntimeException`으로 축소
- Plan 문서 추가: `plan/21_backend_p1_exception_standardization.md`

## 예상되는 결과
- 파일 계층 예외 의미가 명확해지고 응답 매핑이 일관됩니다.
- 운영 장애 시 원인 분류가 쉬워집니다.

## 테스트
- [x] Backend test

실행 로그/결과:
```text
backend: ./gradlew test -> BUILD SUCCESSFUL
```

## 관련 이슈
- Closes #25

## 체크리스트
- [x] 목적/원인/해결/상세/결과 구조를 분리했다.
- [x] P1 범위에서 불필요한 기능 변경 없이 리팩토링에 집중했다.
