### PR TITLE
feat(file): 다건 삭제 결과 모델 및 부분실패 리포트 도입

### DIFF
--- a/backend/src/main/java/com/manas/backend/context/file/application/port/in/DeleteFilesResult.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/in/DeleteFilesResult.java
@@ -1,0 +1,10 @@
+package com.manas.backend.context.file.application.port.in;
+
+import java.util.List;
+
+public record DeleteFilesResult(
+        List<String> deleted,
+        List<DeleteFailure> failed
+) {
+    public record DeleteFailure(String path, String reason) {}
+}

--- a/backend/src/main/java/com/manas/backend/context/file/application/port/in/DeleteFilesUseCase.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/in/DeleteFilesUseCase.java
@@ -5,6 +5,6 @@ import java.util.UUID;
 
 public interface DeleteFilesUseCase {
 
-    void deleteFiles(List<String> paths, UUID userId);
+    DeleteFilesResult deleteFiles(List<String> paths, UUID userId);
 
 }

--- a/backend/src/main/java/com/manas/backend/context/file/application/service/DeleteFilesService.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/service/DeleteFilesService.java
@@ -1,8 +1,10 @@
 package com.manas.backend.context.file.application.service;
 
+import com.manas.backend.context.file.application.port.in.DeleteFilesResult;
 import com.manas.backend.context.file.application.port.in.DeleteFilesUseCase;
 import com.manas.backend.context.file.application.port.out.FileStoragePort;
 import com.manas.backend.context.system.application.port.in.RecordAuditLogUseCase;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -18,25 +20,24 @@ public class DeleteFilesService implements DeleteFilesUseCase {
     private final RecordAuditLogUseCase recordAuditLogUseCase;
 
     @Override
-    public void deleteFiles(List<String> paths, UUID userId) {
+    public DeleteFilesResult deleteFiles(List<String> paths, UUID userId) {
         log.info("User {} requested deletion of {} files", userId, paths.size());
 
-        // TODO: This loop is not atomic. If the 3rd file fails, the first 2 are already deleted.
-        // For a file system, true rollback is hard.
-        // We could implement a "Trash" mechanism later (Soft Delete).
+        List<String> deleted = new ArrayList<>();
+        List<DeleteFilesResult.DeleteFailure> failed = new ArrayList<>();
+
         for (String path : paths) {
             try {
                 fileStoragePort.delete(path, userId);
                 recordAuditLogUseCase.record(userId, "DELETE_FILE", path, "N/A", "SUCCESS");
+                deleted.add(path);
             } catch (RuntimeException e) {
                 log.error("Failed to delete file: {}", path, e);
                 recordAuditLogUseCase.record(userId, "DELETE_FILE", path, "N/A", "FAILURE");
-                // We choose to continue deleting others, or throw?
-                // Usually for a batch delete, we might want to stop or return a report.
-                // For now, let's fail fast to warn the user.
-                throw e;
+                failed.add(new DeleteFilesResult.DeleteFailure(path, e.getMessage()));
             }
         }
-    }
 
+        return new DeleteFilesResult(deleted, failed);
+    }
 }

--- a/backend/src/main/java/com/manas/backend/context/file/infrastructure/web/dto/DeleteFilesResponse.java
+++ b/backend/src/main/java/com/manas/backend/context/file/infrastructure/web/dto/DeleteFilesResponse.java
@@ -1,0 +1,10 @@
+package com.manas.backend.context.file.infrastructure.web.dto;
+
+import java.util.List;
+
+public record DeleteFilesResponse(
+        List<String> deleted,
+        List<DeleteFailureDto> failed
+) {
+    public record DeleteFailureDto(String path, String reason) {}
+}

--- a/plan/22_backend_p1_delete_batch_policy.md
+++ b/plan/22_backend_p1_delete_batch_policy.md
@@ -1,0 +1,15 @@
+# #26 구현 계획 - 다건 삭제 부분실패 정책/응답 모델 정립
+
+## 수정 목적
+- 다건 삭제의 부분 성공/실패를 API 응답으로 명시해 사용자 예측 가능성과 운영 분석성을 높인다.
+
+## 수정할 부분
+1. `DeleteFilesUseCase` 반환형을 결과 모델로 확장
+2. `DeleteFilesService`를 best-effort 정책으로 변경
+   - 성공 목록/실패 목록 수집
+3. `AdminFileController` 응답 DTO 추가
+4. 테스트 보강
+   - 성공/실패 혼합 시 리포트 검증
+
+## 테스트 계획
+- backend: `./gradlew test`


### PR DESCRIPTION
## PR 작성 목적
다건 삭제의 부분 성공/실패를 API 응답으로 명시해 사용자와 운영자가 결과를 명확히 확인할 수 있게 합니다.

## 원인
기존 구현은 중간 실패 시 예외 전파 중심이라 부분 성공 상태를 응답으로 전달하지 못했습니다.

## 해결이 필요한 내용
- 다건 삭제 결과 모델 도입
- 서비스 정책을 best-effort + 실패 리포트로 명시
- 컨트롤러 응답 DTO 확장

## 상세내용
- `DeleteFilesUseCase` 반환형: `DeleteFilesResult`
- `DeleteFilesService`
  - 각 path 삭제 시 성공/실패를 누적
  - 실패 건도 감사로그 기록 후 다음 항목 진행
- `AdminFileController`
  - `DeleteFilesResponse`로 성공/실패 목록 반환
- 테스트
  - `DeleteFilesServiceTest`를 부분실패 리포트 검증으로 갱신
- Plan
  - `plan/22_backend_p1_delete_batch_policy.md`

## 예상되는 결과
- 사용자에게 예측 가능한 삭제 결과를 제공
- 운영 관점에서 실패 경로/원인 추적이 용이

## 테스트
- [x] Backend test

실행 로그/결과:
```text
backend: ./gradlew test -> BUILD SUCCESSFUL
```

## 관련 이슈
- Closes #26
