### PR TITLE
chore(backend): 운영 기본값 하드닝 및 dev SQL 로그 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Or run Docker directly:
 docker-compose up -d
 ```
 
+### Backend Profile Notes
+- Production-safe defaults are in `application.yml` (SQL logs off).
+- For local debugging with SQL logs enabled, use dev profile:
+```bash
+SPRING_PROFILES_ACTIVE=dev
+```
+
 ### Step 3: Connect
 1. Access the Admin UI at [http://localhost:51821](http://localhost:51821).
 2. Login with the password you set in `.env`.

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+spring:
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,9 +27,10 @@ spring:
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
-    show-sql: true
-    hibernate:
-      format_sql: true
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
 
   flyway:
     enabled: true

--- a/plan/23_backend_p2_profile_config_hardening.md
+++ b/plan/23_backend_p2_profile_config_hardening.md
@@ -1,0 +1,15 @@
+# #28 구현 계획 - 환경별 설정 분리 및 운영 기본값 하드닝
+
+## 수정 목적
+- 운영 기본값을 보수적으로 만들고 개발 편의 설정(SQL 출력 등)은 dev 프로파일로 분리한다.
+
+## 수정할 부분
+1. `application.yml`
+   - `spring.jpa.show-sql=false`
+   - `spring.jpa.properties.hibernate.format_sql=false`
+2. `application-dev.yml` 신설
+   - dev에서만 `show-sql=true`, `format_sql=true`
+3. README 운영 가이드에 dev profile 사용 예시 추가
+
+## 테스트 계획
+- backend: `./gradlew test`


### PR DESCRIPTION
## PR 작성 목적
운영 기본값 하드닝을 위해 SQL 디버그 로그 설정을 dev 프로파일로 분리합니다.

## 원인
기본 설정에 SQL 출력이 포함되어 운영 환경에서 로그 과다/민감정보 노출 위험이 있었습니다.

## 해결이 필요한 내용
- 운영 기본 설정에서 SQL 로그 비활성화
- 개발 프로파일에서만 SQL 로그 활성화
- README에 프로파일 사용 가이드 반영

## 상세내용
- `application.yml`
  - `spring.jpa.show-sql=false`
  - `spring.jpa.properties.hibernate.format_sql=false`
- `application-dev.yml` 신설
  - dev에서 `show-sql=true`, `format_sql=true`
- README
  - backend profile 사용 안내 추가
- Plan
  - `plan/23_backend_p2_profile_config_hardening.md`

## 예상되는 결과
- 운영 로그 노이즈 및 보안 리스크 감소
- 개발 환경 디버깅 편의는 유지

## 테스트
- [x] Backend test

실행 로그/결과:
```text
backend: ./gradlew test -> BUILD SUCCESSFUL
```

## 관련 이슈
- Closes #28
