### PR TITLE
feat(file): 디렉터리 목록 pagination/sort 및 메타 응답 도입

### DIFF
--- a/backend/src/main/java/com/manas/backend/context/file/application/port/in/FileListSort.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/in/FileListSort.java
@@ -1,0 +1,8 @@
+package com.manas.backend.context.file.application.port.in;
+
+public enum FileListSort {
+    NAME_ASC,
+    NAME_DESC,
+    MODIFIED_DESC,
+    MODIFIED_ASC
+}

--- a/backend/src/main/java/com/manas/backend/context/file/application/port/in/ListDirectoryQuery.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/in/ListDirectoryQuery.java
@@ -1,0 +1,12 @@
+package com.manas.backend.context.file.application.port.in;
+
+import java.util.UUID;
+
+public record ListDirectoryQuery(
+        String path,
+        UUID userId,
+        int offset,
+        int limit,
+        FileListSort sort
+) {
+}

--- a/backend/src/main/java/com/manas/backend/context/file/application/port/in/ListDirectoryUseCase.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/in/ListDirectoryUseCase.java
@@ -1,8 +1,7 @@
 package com.manas.backend.context.file.application.port.in;
 
 import com.manas.backend.context.file.domain.DirectoryListing;
-import java.util.UUID;
 
 public interface ListDirectoryUseCase {
-    DirectoryListing listDirectory(String path, UUID userId);
+    DirectoryListing listDirectory(ListDirectoryQuery query);
 }

--- a/backend/src/main/java/com/manas/backend/context/file/application/port/out/FileStoragePort.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/port/out/FileStoragePort.java
@@ -1,5 +1,6 @@
 package com.manas.backend.context.file.application.port.out;
 
+import com.manas.backend.context.file.application.port.in.FileListSort;
 import com.manas.backend.context.file.domain.DirectoryListing;
 import com.manas.backend.context.file.domain.FileContent;
 import java.util.UUID;
@@ -13,7 +14,7 @@ public interface FileStoragePort {
      * @throws SecurityException if path is outside allowed scope.
      * @throws IllegalArgumentException if path is invalid.
      */
-    DirectoryListing listDirectory(String path, UUID userId);
+    DirectoryListing listDirectory(String path, UUID userId, int offset, int limit, FileListSort sort);
 
     /**
      * Deletes a file or directory at the specified path.

--- a/backend/src/main/java/com/manas/backend/context/file/application/service/ListDirectoryService.java
+++ b/backend/src/main/java/com/manas/backend/context/file/application/service/ListDirectoryService.java
@@ -1,12 +1,11 @@
 package com.manas.backend.context.file.application.service;
 
+import com.manas.backend.context.file.application.port.in.ListDirectoryQuery;
 import com.manas.backend.context.file.application.port.in.ListDirectoryUseCase;
 import com.manas.backend.context.file.application.port.out.FileStoragePort;
 import com.manas.backend.context.file.domain.DirectoryListing;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -15,9 +14,16 @@ public class ListDirectoryService implements ListDirectoryUseCase {
     private final FileStoragePort fileStoragePort;
 
     @Override
-    public DirectoryListing listDirectory(String path, UUID userId) {
-        // Business logic could be added here (e.g. detailed logging, validation that isn't infra-specific)
-        // For now, delegate to the port.
-        return fileStoragePort.listDirectory(path, userId);
+    public DirectoryListing listDirectory(ListDirectoryQuery query) {
+        int normalizedOffset = Math.max(0, query.offset());
+        int normalizedLimit = Math.min(Math.max(1, query.limit()), 500);
+
+        return fileStoragePort.listDirectory(
+                query.path(),
+                query.userId(),
+                normalizedOffset,
+                normalizedLimit,
+                query.sort()
+        );
     }
 }

--- a/backend/src/main/java/com/manas/backend/context/file/domain/DirectoryListing.java
+++ b/backend/src/main/java/com/manas/backend/context/file/domain/DirectoryListing.java
@@ -5,5 +5,8 @@ import java.util.List;
 public record DirectoryListing(
     String currentPath,
     List<PathNode> breadcrumbs,
-    List<FileNode> items
+    List<FileNode> items,
+    int totalCount,
+    int offset,
+    int limit
 ) {}

--- a/backend/src/main/java/com/manas/backend/context/file/infrastructure/web/AdminFileController.java
+++ b/backend/src/main/java/com/manas/backend/context/file/infrastructure/web/AdminFileController.java
@@ -2,6 +2,8 @@ package com.manas.backend.context.file.infrastructure.web;
 
 import com.manas.backend.context.file.application.port.in.DeleteFilesResult;
 import com.manas.backend.context.file.application.port.in.DeleteFilesUseCase;
+import com.manas.backend.context.file.application.port.in.FileListSort;
+import com.manas.backend.context.file.application.port.in.ListDirectoryQuery;
 import com.manas.backend.context.file.application.port.in.ListDirectoryUseCase;
 import com.manas.backend.context.file.application.port.in.MoveFileUseCase;
 import com.manas.backend.context.file.domain.DirectoryListing;
@@ -35,9 +37,14 @@ public class AdminFileController {
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<DirectoryListingDTO> listFiles(
             @RequestParam(required = false) String path,
-            @RequestParam(required = false) UUID userId
+            @RequestParam(required = false) UUID userId,
+            @RequestParam(defaultValue = "0") int offset,
+            @RequestParam(defaultValue = "100") int limit,
+            @RequestParam(defaultValue = "NAME_ASC") FileListSort sort
     ) {
-        DirectoryListing result = listDirectoryUseCase.listDirectory(path, userId);
+        DirectoryListing result = listDirectoryUseCase.listDirectory(
+                new ListDirectoryQuery(path, userId, offset, limit, sort)
+        );
         return ResponseEntity.ok(fileMapper.toDTO(result));
     }
 

--- a/backend/src/main/java/com/manas/backend/context/file/infrastructure/web/dto/DirectoryListingDTO.java
+++ b/backend/src/main/java/com/manas/backend/context/file/infrastructure/web/dto/DirectoryListingDTO.java
@@ -5,5 +5,8 @@ import java.util.List;
 public record DirectoryListingDTO(
     String currentPath,
     List<PathNodeDTO> breadcrumbs,
-    List<FileNodeDTO> items
+    List<FileNodeDTO> items,
+    int totalCount,
+    int offset,
+    int limit
 ) {}

--- a/backend/src/test/java/com/manas/backend/context/file/application/service/ListDirectoryServiceTest.java
+++ b/backend/src/test/java/com/manas/backend/context/file/application/service/ListDirectoryServiceTest.java
@@ -1,0 +1,40 @@
+package com.manas.backend.context.file.application.service;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.manas.backend.context.file.application.port.in.FileListSort;
+import com.manas.backend.context.file.application.port.in.ListDirectoryQuery;
+import com.manas.backend.context.file.application.port.out.FileStoragePort;
+import com.manas.backend.context.file.domain.DirectoryListing;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ListDirectoryServiceTest {
+
+    @Mock
+    private FileStoragePort fileStoragePort;
+
+    @InjectMocks
+    private ListDirectoryService listDirectoryService;
+
+    @Test
+    void shouldNormalizeOffsetAndLimit() {
+        UUID userId = UUID.randomUUID();
+        DirectoryListing listing = new DirectoryListing("/", List.of(), List.of(), 0, 0, 1);
+
+        when(fileStoragePort.listDirectory(eq("/"), eq(userId), eq(0), eq(500), eq(FileListSort.NAME_ASC)))
+                .thenReturn(listing);
+
+        listDirectoryService.listDirectory(new ListDirectoryQuery("/", userId, -10, 9999, FileListSort.NAME_ASC));
+
+        verify(fileStoragePort).listDirectory("/", userId, 0, 500, FileListSort.NAME_ASC);
+    }
+}

--- a/plan/24_backend_p2_file_list_pagination_sort.md
+++ b/plan/24_backend_p2_file_list_pagination_sort.md
@@ -1,0 +1,14 @@
+# #27 구현 계획 - 디렉터리 목록 조회 pagination/sort 성능 개선
+
+## 수정 목적
+- 디렉터리 목록 API에 pagination/sort를 도입해 대량 목록 조회 시 부하를 제어한다.
+
+## 수정할 부분
+1. 목록 조회 요청 모델 도입 (`offset`, `limit`, `sort`)
+2. `ListDirectoryUseCase`/`FileStoragePort` 시그니처 확장
+3. `LocalFileSystemAdapter`에 정렬/페이지네이션 적용
+4. 응답에 `totalCount`, `offset`, `limit` 포함
+5. 테스트 추가(정렬/페이지네이션)
+
+## 테스트 계획
+- backend: `./gradlew test`


### PR DESCRIPTION
## PR 작성 목적
대량 디렉터리 조회 성능 리스크를 낮추기 위해 목록 API에 pagination/sort를 도입합니다.

## 원인
기존 목록 조회는 전체 로딩 중심으로, 파일 수가 많을수록 응답 지연/부하가 증가할 수 있었습니다.

## 해결이 필요한 내용
- 목록 조회 쿼리 모델 도입(offset/limit/sort)
- usecase/port/adapter 계층 전체 시그니처 정합성 확보
- 응답에 totalCount/offset/limit 메타 포함

## 상세내용
- Query/Sort 모델 추가
  - `ListDirectoryQuery`, `FileListSort`
- `ListDirectoryUseCase` / `FileStoragePort` 확장
  - `offset`, `limit`, `sort` 처리
- `ListDirectoryService`
  - offset/limit 정규화(음수 방지, limit 상한 500)
- `LocalFileSystemAdapter`
  - sort comparator 적용
  - paging slicing 적용
- `AdminFileController`
  - `/api/admin/files/list`에 `offset`, `limit`, `sort` query 지원
- `DirectoryListing`/`DirectoryListingDTO`
  - `totalCount`, `offset`, `limit` 추가
- 테스트
  - `ListDirectoryServiceTest` 추가(정규화 검증)
- Plan
  - `plan/24_backend_p2_file_list_pagination_sort.md`

## 예상되는 결과
- 대량 파일 환경에서 한 번에 반환되는 데이터 크기를 제어 가능
- 서버/클라이언트 모두에서 확장 가능한 목록 조회 기반 확보

## 테스트
- [x] Backend test

실행 로그/결과:
```text
backend: ./gradlew test -> BUILD SUCCESSFUL
```

## 관련 이슈
- Closes #27
