### PR TITLE
chore(backend): Gradle configuration cache 기본 활성화

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ docker-compose up -d
 SPRING_PROFILES_ACTIVE=dev
 ```
 
+### Backend Build Performance Notes
+- Gradle configuration cache is enabled in `backend/gradle.properties`.
+- First build warms cache; repeated runs are faster.
+
 ### Step 3: Connect
 1. Access the Admin UI at [http://localhost:51821](http://localhost:51821).
 2. Login with the password you set in `.env`.

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.configuration-cache=true
+org.gradle.parallel=true
+org.gradle.daemon=true

--- a/plan/25_backend_p3_gradle_build_perf.md
+++ b/plan/25_backend_p3_gradle_build_perf.md
@@ -1,0 +1,14 @@
+# #33 구현 계획 - Gradle configuration cache 기반 빌드 성능 최적화
+
+## 수정 목적
+- 반복 빌드/테스트 시간을 줄이기 위해 Gradle configuration cache를 활성화한다.
+
+## 수정할 부분
+1. `backend/gradle.properties` 신설
+   - `org.gradle.configuration-cache=true`
+   - `org.gradle.parallel=true`
+   - `org.gradle.daemon=true`
+2. README에 로컬 빌드 성능 팁 추가
+
+## 테스트 계획
+- backend: `./gradlew test` 2회 실행 (2회차 cache reuse 확인)


### PR DESCRIPTION
## PR 작성 목적
반복 빌드 성능 개선을 위해 backend Gradle configuration cache 기본값을 활성화합니다.

## 원인
테스트 실행 로그에서 configuration cache 활성화가 지속 권장되고 있었고, 반복 실행 시 구성 단계 비용이 낭비되고 있었습니다.

## 해결이 필요한 내용
- `backend/gradle.properties`에 빌드 성능 기본값 추가
- 문서에 동작/효과 안내 반영

## 상세내용
- `backend/gradle.properties` 신설
  - `org.gradle.configuration-cache=true`
  - `org.gradle.parallel=true`
  - `org.gradle.daemon=true`
- `README.md`
  - Backend Build Performance Notes 추가
- plan
  - `plan/25_backend_p3_gradle_build_perf.md`

## 예상되는 결과
- 반복 테스트/빌드에서 설정 캐시 재사용으로 실행 시간이 단축됩니다.

## 테스트
- [x] Backend test (2회)

실행 로그/결과:
```text
1st run: Configuration cache entry stored.
2nd run: Reusing configuration cache. / entry reused.
```

## 관련 이슈
- Closes #33
