### PR TITLE
chore(infra): DB 자격증명 env 시크릿화 및 preflight 검증 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ WG_PASSWORD_HASH=replace_with_bcrypt_hash
 # Linux: /mnt/data
 HOST_VOLUMES_PATH=/Volumes
 
+# Database credentials
+NAS_USER=nas_user
+NAS_PASSWORD=change_db_password
+NAS_DB=nas_db
+
 # Backend bootstrap admin password (required on first startup)
 APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD=change_me_now
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Detailed specifications and architectural decisions can be found in the `spec/` 
    - `JWT_SECRET` (Base64, decoded length >= 32 bytes)
    - `WG_HOST` (Public IP or DDNS)
    - `WG_PASSWORD_HASH` (wg-easy admin password hash)
+   - `NAS_USER`, `NAS_PASSWORD`, `NAS_DB` (PostgreSQL credentials)
    - `TRUSTED_PROXY_SUBNETS` (X-Forwarded-For를 신뢰할 프록시 CIDR 목록)
    - `FRONTEND_BIND_ADDRESS` (frontend host bind address, secure default: `127.0.0.1`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,9 @@ services:
     image: postgres:16-alpine
     container_name: nas-db
     environment:
-      POSTGRES_USER: nas_user
-      POSTGRES_PASSWORD: nas_password
-      POSTGRES_DB: nas_db
+      POSTGRES_USER: ${NAS_USER}
+      POSTGRES_PASSWORD: ${NAS_PASSWORD}
+      POSTGRES_DB: ${NAS_DB}
     volumes:
       - ./config/db-data:/var/lib/postgresql/data
     restart: unless-stopped
@@ -41,9 +41,9 @@ services:
     build: ./backend
     container_name: nas-backend
     environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://nas-db:5432/nas_db
-      SPRING_DATASOURCE_USERNAME: nas_user
-      SPRING_DATASOURCE_PASSWORD: nas_password
+      SPRING_DATASOURCE_URL: jdbc:postgresql://nas-db:5432/${NAS_DB}
+      SPRING_DATASOURCE_USERNAME: ${NAS_USER}
+      SPRING_DATASOURCE_PASSWORD: ${NAS_PASSWORD}
       APP_STORAGE_ROOT: /mnt/host_volumes
       JWT_SECRET: ${JWT_SECRET}
       APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD: ${APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD}

--- a/plan/27_infra_db_credentials_env.md
+++ b/plan/27_infra_db_credentials_env.md
@@ -1,0 +1,18 @@
+# #36 구현 계획 - DB 자격증명 하드코딩 제거
+
+## 수정 목적
+- DB 계정/비밀번호 하드코딩을 제거하고 `.env` 기반 시크릿 주입으로 전환한다.
+
+## 수정할 부분
+1. `docker-compose.yml`
+   - Postgres/Backend DB 설정을 `${NAS_USER}`, `${NAS_PASSWORD}`, `${NAS_DB}`로 치환
+2. `.env.example`
+   - DB 관련 변수 추가
+3. `start.sh`
+   - `.env` 생성 시 DB 변수 추가
+   - preflight에서 DB 시크릿 누락 검증
+4. `README`
+   - DB 환경변수 필수 안내
+
+## 테스트 계획
+- `docker-compose config` 렌더 확인

--- a/start.sh
+++ b/start.sh
@@ -49,6 +49,16 @@ ensure_env_file() {
   read -r -p "Enter Host Path to share [${default_volumes}]: " host_volumes_path
   host_volumes_path=${host_volumes_path:-$default_volumes}
 
+  read -r -p "Enter DB user [nas_user]: " nas_user
+  nas_user=${nas_user:-nas_user}
+
+  read -r -p "Enter DB password [change_db_password]: " nas_password
+  nas_password=${nas_password:-change_db_password}
+
+  read -r -p "Enter DB name [nas_db]: " nas_db
+  nas_db=${nas_db:-nas_db}
+
+
 
   read -r -p "Enter frontend bind address [127.0.0.1]: " frontend_bind_address
   frontend_bind_address=${frontend_bind_address:-127.0.0.1}
@@ -65,6 +75,9 @@ ensure_env_file() {
 WG_HOST=${wg_host}
 WG_PASSWORD_HASH=${wg_password_hash}
 HOST_VOLUMES_PATH=${host_volumes_path}
+NAS_USER=${nas_user}
+NAS_PASSWORD=${nas_password}
+NAS_DB=${nas_db}
 APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD=${bootstrap_admin_password}
 JWT_SECRET=${jwt_secret}
 TRUSTED_PROXY_SUBNETS=127.0.0.1/32,::1/128
@@ -107,11 +120,14 @@ validate_jwt_secret() {
 preflight_security_checks() {
   print_info "Running security preflight checks..."
 
-  local wg_password_hash bootstrap_admin_password jwt_secret frontend_bind_address
+  local wg_password_hash bootstrap_admin_password jwt_secret frontend_bind_address nas_user nas_password nas_db
   wg_password_hash=$(get_env_value "WG_PASSWORD_HASH")
   bootstrap_admin_password=$(get_env_value "APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD")
   jwt_secret=$(get_env_value "JWT_SECRET")
   frontend_bind_address=$(get_env_value "FRONTEND_BIND_ADDRESS")
+  nas_user=$(get_env_value "NAS_USER")
+  nas_password=$(get_env_value "NAS_PASSWORD")
+  nas_db=$(get_env_value "NAS_DB")
 
   if [[ -z "$wg_password_hash" ]]; then
     print_err "WG_PASSWORD_HASH is missing in .env"
@@ -120,6 +136,11 @@ preflight_security_checks() {
 
   if [[ -z "$bootstrap_admin_password" ]]; then
     print_err "APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD is missing in .env"
+    exit 1
+  fi
+
+  if [[ -z "$nas_user" || -z "$nas_password" || -z "$nas_db" ]]; then
+    print_err "NAS_USER/NAS_PASSWORD/NAS_DB must be set in .env"
     exit 1
   fi
 


### PR DESCRIPTION
## PR 작성 목적
DB 자격증명 하드코딩을 제거하고 `.env` 기반 시크릿 주입으로 전환해 운영 보안을 강화합니다.

## 원인
compose 파일에 고정된 DB user/password가 남아 있어 환경 분리/보안 관리가 취약했습니다.

## 해결이 필요한 내용
- compose의 DB 설정 env 치환
- `.env.example`/`start.sh`/README 동기화
- preflight에서 DB 시크릿 누락 검증

## 상세내용
- `docker-compose.yml`
  - Postgres: `POSTGRES_USER/PASSWORD/DB` -> `${NAS_USER}`, `${NAS_PASSWORD}`, `${NAS_DB}`
  - Backend datasource도 동일 env 참조
- `.env.example`
  - `NAS_USER`, `NAS_PASSWORD`, `NAS_DB` 추가
- `start.sh`
  - `.env` 생성 시 DB 변수 입력/저장
  - preflight에서 DB 변수 누락 시 fail-fast
- `README.md`
  - 환경설정 항목에 DB 변수 추가
- plan
  - `plan/27_infra_db_credentials_env.md`

## 예상되는 결과
- 운영 환경별 시크릿 분리 가능
- DB 자격증명 하드코딩 리스크 제거

## 테스트
- [x] Compose config render 확인

실행 로그/결과:
```text
NAS_USER=... NAS_PASSWORD=... NAS_DB=... docker-compose config -> OK
```

## 관련 이슈
- Closes #36
