### PR TITLE
chore(vpn): wg-easy 이미지 버전 pinning 도입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Public IP or Hostname for WireGuard
 WG_HOST=auto
 
+# wg-easy image version (pin exact version for reproducible deploys)
+WG_EASY_VERSION=15
+
 # VPN Admin Password hash for wg-easy (bcrypt hash)
 # You can generate this automatically via ./start.sh
 WG_PASSWORD_HASH=replace_with_bcrypt_hash

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Detailed specifications and architectural decisions can be found in the `spec/` 
    - `APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD` (initial admin password)
    - `JWT_SECRET` (Base64, decoded length >= 32 bytes)
    - `WG_HOST` (Public IP or DDNS)
+   - `WG_EASY_VERSION` (pinned wg-easy image version)
    - `WG_PASSWORD_HASH` (wg-easy admin password hash)
    - `NAS_USER`, `NAS_PASSWORD`, `NAS_DB` (PostgreSQL credentials)
    - `TRUSTED_PROXY_SUBNETS` (X-Forwarded-For를 신뢰할 프록시 CIDR 목록)
@@ -124,6 +125,7 @@ SPRING_PROFILES_ACTIVE=dev
 - On your home router, **forward UDP port 51820** to your Mac's local IP address.
 - Do **not** forward port 80 publicly unless you explicitly intend to expose the frontend.
 - Keep `FRONTEND_BIND_ADDRESS=127.0.0.1` by default for safer local-only bind.
+- Keep `WG_EASY_VERSION` pinned. Upgrade by explicitly changing version, reviewing changelog, then redeploying.
 
 ---
 *© 2026 Private NAS Project. Created with Vibe.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   wg-easy:
-    image: ghcr.io/wg-easy/wg-easy
+    image: ghcr.io/wg-easy/wg-easy:${WG_EASY_VERSION}
     container_name: nas-vpn
     environment:
       - WG_HOST=${WG_HOST}

--- a/plan/28_vpn_wgeasy_image_pinning.md
+++ b/plan/28_vpn_wgeasy_image_pinning.md
@@ -1,0 +1,17 @@
+# #39 구현 계획 - wg-easy 이미지 버전 pinning
+
+## 수정 목적
+- VPN 컨테이너 버전 변동 리스크를 줄이고 배포 재현성을 높인다.
+
+## 수정할 부분
+1. `docker-compose.yml`
+   - `image: ghcr.io/wg-easy/wg-easy` -> `ghcr.io/wg-easy/wg-easy:${WG_EASY_VERSION}`
+2. `.env.example`
+   - `WG_EASY_VERSION` 기본값 추가
+3. `start.sh`
+   - `.env` 생성 시 `WG_EASY_VERSION` 기본값 기입
+4. `README`
+   - 버전 고정/업그레이드 절차 안내 추가
+
+## 테스트 계획
+- `docker-compose config` 렌더링 확인

--- a/start.sh
+++ b/start.sh
@@ -31,6 +31,10 @@ ensure_env_file() {
   read -r -p "Enter your Public IP/Hostname for VPN [${default_host}]: " wg_host
   wg_host=${wg_host:-$default_host}
 
+  read -r -p "Enter wg-easy image version [15]: " wg_easy_version
+  wg_easy_version=${wg_easy_version:-15}
+
+
   read -r -p "Enter VPN Admin Password [admin123]: " wg_password
   wg_password=${wg_password:-admin123}
 
@@ -73,6 +77,7 @@ ensure_env_file() {
 
   cat > .env <<EOF
 WG_HOST=${wg_host}
+WG_EASY_VERSION=${wg_easy_version}
 WG_PASSWORD_HASH=${wg_password_hash}
 HOST_VOLUMES_PATH=${host_volumes_path}
 NAS_USER=${nas_user}
@@ -120,7 +125,7 @@ validate_jwt_secret() {
 preflight_security_checks() {
   print_info "Running security preflight checks..."
 
-  local wg_password_hash bootstrap_admin_password jwt_secret frontend_bind_address nas_user nas_password nas_db
+  local wg_password_hash bootstrap_admin_password jwt_secret frontend_bind_address nas_user nas_password nas_db wg_easy_version
   wg_password_hash=$(get_env_value "WG_PASSWORD_HASH")
   bootstrap_admin_password=$(get_env_value "APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD")
   jwt_secret=$(get_env_value "JWT_SECRET")
@@ -128,9 +133,15 @@ preflight_security_checks() {
   nas_user=$(get_env_value "NAS_USER")
   nas_password=$(get_env_value "NAS_PASSWORD")
   nas_db=$(get_env_value "NAS_DB")
+  wg_easy_version=$(get_env_value "WG_EASY_VERSION")
 
   if [[ -z "$wg_password_hash" ]]; then
     print_err "WG_PASSWORD_HASH is missing in .env"
+    exit 1
+  fi
+
+  if [[ -z "$wg_easy_version" ]]; then
+    print_err "WG_EASY_VERSION is missing in .env"
     exit 1
   fi
 


### PR DESCRIPTION
## PR 작성 목적
VPN 운영 재현성과 안정성을 위해 `wg-easy` 이미지 버전을 pinning 방식으로 전환합니다.

## 원인
기존 `ghcr.io/wg-easy/wg-easy` latest 추적은 예기치 않은 동작 변경 위험이 있습니다.

## 해결이 필요한 내용
- compose에서 이미지 버전 env pinning
- `.env.example`/`start.sh`/README 동기화

## 상세내용
- `docker-compose.yml`
  - `image: ghcr.io/wg-easy/wg-easy:${WG_EASY_VERSION}`
- `.env.example`
  - `WG_EASY_VERSION=15` 추가
- `start.sh`
  - `.env` 생성 시 `WG_EASY_VERSION` 입력/저장
  - preflight에서 누락 검증
- `README`
  - 버전 pinning/업그레이드 절차 안내 추가
- plan
  - `plan/28_vpn_wgeasy_image_pinning.md`

## 예상되는 결과
- 배포 재현성 향상
- 운영 중 예기치 않은 이미지 변경 리스크 감소

## 테스트
- [x] Compose config render 확인

실행 로그/결과:
```text
WG_EASY_VERSION=15 ... docker-compose config -> OK
```

## 관련 이슈
- Closes #39
