### PR TITLE
feat(monitoring): compose healthcheck 및 backend readiness 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ Or run Docker directly:
 docker-compose up -d
 ```
 
+### Health Check & Monitoring Quick Check
+```bash
+docker-compose ps
+docker-compose logs --tail=100 nas-db nas-backend nas-frontend
+```
+- `nas-db`: `pg_isready` 기반 healthy
+- `nas-backend`: `GET /actuator/health` 상태 기반 healthy
+- `nas-frontend`: nginx index 응답 기반 healthy
+
 ### Backend Profile Notes
 - Production-safe defaults are in `application.yml` (SQL logs off).
 - For local debugging with SQL logs enabled, use dev profile:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,8 @@ RUN ./gradlew bootJar --no-daemon
 # Stage 2: Run
 FROM eclipse-temurin:25-jre
 WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 EXPOSE 8080

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -49,3 +49,14 @@ security:
     allowed-subnets: 10.8.0.0/24,127.0.0.1/32,172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
   network:
     trusted-proxies: ${TRUSTED_PROXY_SUBNETS:127.0.0.1/32,::1/128}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: never

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,12 @@ services:
       POSTGRES_DB: ${NAS_DB}
     volumes:
       - ./config/db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${NAS_USER} -d ${NAS_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
     restart: unless-stopped
     networks:
       - nas_network
@@ -50,8 +56,15 @@ services:
       TRUSTED_PROXY_SUBNETS: ${TRUSTED_PROXY_SUBNETS:-127.0.0.1/32,::1/128}
     volumes:
       - ${HOST_VOLUMES_PATH:-/Volumes}:/mnt/host_volumes:rw
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     depends_on:
-      - nas-db
+      nas-db:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - nas_network
@@ -61,8 +74,15 @@ services:
     container_name: nas-frontend
     ports:
       - "${FRONTEND_BIND_ADDRESS:-127.0.0.1}:80:80"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost/ >/dev/null 2>&1"]
+      interval: 20s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
     depends_on:
-      - nas-backend
+      nas-backend:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - nas_network

--- a/plan/30_monitoring_healthcheck_hardening.md
+++ b/plan/30_monitoring_healthcheck_hardening.md
@@ -1,0 +1,18 @@
+# #43 구현 계획 - 서비스 헬스체크/모니터링 기본 구성 강화
+
+## 수정 목적
+- compose 레벨 healthcheck를 추가해 운영 감시성과 기동 안정성을 개선한다.
+
+## 수정할 부분
+1. backend actuator health 노출 최소 설정 추가
+2. backend runtime 이미지에 healthcheck용 curl 추가
+3. docker-compose healthcheck 추가
+   - nas-db: pg_isready
+   - nas-backend: /actuator/health
+   - nas-frontend: nginx index 응답 확인
+4. depends_on 조건을 service_healthy로 강화
+5. README 운영 점검 절차 추가
+
+## 테스트 계획
+- `docker-compose config` 렌더링 확인
+- backend `./gradlew test`


### PR DESCRIPTION
## PR 작성 목적
운영 안정성 향상을 위해 compose 기반 헬스체크와 backend actuator readiness 구성을 보강합니다.

## 원인
서비스 readiness/health 기준이 약하면 장애 감지 지연 및 의존 서비스 준비 전 기동 문제가 발생할 수 있습니다.

## 해결이 필요한 내용
- DB/Backend/Frontend healthcheck 추가
- backend health endpoint 운영 노출 최소 설정
- depends_on health gating 정비

## 상세내용
- `backend/src/main/resources/application.yml`
  - actuator web exposure를 `health,info`로 제한
  - health probes enabled, show-details=never
- `backend/Dockerfile`
  - healthcheck 호출용 `curl` 설치
- `docker-compose.yml`
  - `nas-db`: `pg_isready` healthcheck
  - `nas-backend`: `/actuator/health` healthcheck
  - `nas-frontend`: nginx index healthcheck
  - `depends_on`을 `condition: service_healthy`로 강화
- `README.md`
  - 운영 헬스체크 quick check 절차 추가
- plan
  - `plan/30_monitoring_healthcheck_hardening.md`

## 예상되는 결과
- 장애 조기 감지 및 기동 안정성 향상
- 운영 점검 절차 표준화

## 테스트
- [x] docker-compose config 렌더 확인
- [x] backend test

실행 로그/결과:
```text
docker-compose config -> OK
backend: ./gradlew test -> BUILD SUCCESSFUL
```

## 관련 이슈
- Closes #43
