### PR TITLE
fix(backend): 로컬 실행 호환 cache-dir 기본값으로 조정

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ docker-compose logs --tail=100 nas-db nas-backend nas-frontend
 ```bash
 SPRING_PROFILES_ACTIVE=dev
 ```
+- If needed, override preview cache directory explicitly:
+```bash
+APP_STORAGE_CACHE_DIR=/tmp/nas-cache
+```
 
 ### Backend Build Performance Notes
 - Gradle configuration cache is enabled in `backend/gradle.properties`.

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ logging:
 app:
   storage:
     root: /mnt/host_volumes
-    cache-dir: /app/cache
+    cache-dir: ${APP_STORAGE_CACHE_DIR:/tmp/nas-cache}
   security:
     bootstrap-admin-password: ${APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD:}
 

--- a/plan/31_fix_backend_cache_dir_default.md
+++ b/plan/31_fix_backend_cache_dir_default.md
@@ -1,0 +1,14 @@
+# #46 구현 계획 - preview cache-dir 기본값 로컬 실행 호환성 개선
+
+## 수정 목적
+- 비컨테이너 로컬 실행에서 `/app/cache` 경로 문제로 backend 기동 실패가 나지 않도록 기본값을 안전하게 변경한다.
+
+## 수정할 부분
+1. `application.yml`
+   - `app.storage.cache-dir`를 env 우선 + 안전 기본값으로 변경
+2. `README`
+   - 로컬 실행 시 cache-dir override 가이드 추가
+
+## 테스트 계획
+- backend: `./gradlew test`
+- 로컬 실행 스모크: backend jar 기동 확인


### PR DESCRIPTION
## PR 작성 목적
로컬/비컨테이너 실행에서 preview cache-dir 기본 경로로 인한 기동 실패를 방지합니다.

## 원인
기본값 `/app/cache`는 로컬 실행 환경에서 write 불가일 수 있어 PreviewService 초기화가 실패합니다.

## 해결
- `app.storage.cache-dir` 기본값을 `${APP_STORAGE_CACHE_DIR:/tmp/nas-cache}`로 변경
- README에 cache-dir override 가이드 추가
- 계획 문서 추가: `plan/31_fix_backend_cache_dir_default.md`

## 테스트
- [x] backend `./gradlew test` 통과

## 관련 이슈
- Closes #46
