### PR TITLE
fix(infra): 기존 db-data와 credentials drift 가드 경고 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Detailed specifications and architectural decisions can be found in the `spec/` 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed on your Mac.
 
 ### Step 1: Configure Environment
+> ⚠️ If `config/db-data` already exists, changing `NAS_USER/NAS_PASSWORD/NAS_DB` later may cause backend DB authentication failures. Reinitialize DB data (after backup) or keep credentials aligned with the existing DB.
+
 1. Copy the example environment file:
    ```bash
    cp .env.example .env

--- a/plan/32_fix_db_credential_drift_guard.md
+++ b/plan/32_fix_db_credential_drift_guard.md
@@ -1,0 +1,14 @@
+# #47 구현 계획 - DB credential drift 가드 강화
+
+## 수정 목적
+- 기존 db-data 유지 상태에서 DB 자격증명 변경 시 backend 인증 실패를 사전 인지하도록 가드/문서를 추가한다.
+
+## 수정할 부분
+1. `start.sh`
+   - `config/db-data/PG_VERSION` 존재 + DB creds 변경 가능성에 대한 경고 출력
+2. `README`
+   - DB credentials 변경 시 재초기화/동기화 절차 명시
+
+## 테스트 계획
+- 스크립트 문법 확인
+- 수동: PG data 디렉터리 존재 시 경고 출력 확인

--- a/start.sh
+++ b/start.sh
@@ -162,6 +162,13 @@ preflight_security_checks() {
   if [[ "${frontend_bind_address:-127.0.0.1}" == "0.0.0.0" ]]; then
     print_info "Warning: FRONTEND_BIND_ADDRESS=0.0.0.0 exposes port 80 on all interfaces. Ensure router/firewall blocks public ingress."
   fi
+
+  if [[ -f "./config/db-data/PG_VERSION" ]]; then
+    print_info "Notice: Existing PostgreSQL data detected (config/db-data)."
+    print_info "If NAS_USER/NAS_PASSWORD/NAS_DB changed since first init, backend may fail to authenticate."
+    print_info "If auth fails, backup data then reinitialize db-data or align credentials with existing DB credentials."
+  fi
+
   print_ok "Security preflight checks passed."
 }
 


### PR DESCRIPTION
## PR 작성 목적
기존 db-data 유지 상태에서 DB credentials 변경 시 backend 인증 실패가 발생하는 운영 함정을 줄입니다.

## 변경 내용
- `start.sh` preflight에 기존 PostgreSQL 데이터(`config/db-data/PG_VERSION`) 감지 경고 추가
- credentials drift 가능성과 복구 가이드를 즉시 출력
- README에 DB credentials 변경 시 주의사항 추가
- 계획 문서 추가: `plan/32_fix_db_credential_drift_guard.md`

## 테스트
- [x] `bash -n start.sh`

## 관련 이슈
- Closes #47
