### PR TITLE
fix(monitoring): actuator health endpoint 인증 차단 해제

### DIFF
--- a/backend/src/main/java/com/manas/backend/context/auth/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/manas/backend/context/auth/infrastructure/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/error").permitAll()
+                .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 .requestMatchers("/api/auth/login").permitAll()
                 .anyRequest().authenticated()
             )

--- a/plan/35_fix_backend_healthcheck_403.md
+++ b/plan/35_fix_backend_healthcheck_403.md
@@ -1,0 +1,11 @@
+# #54 구현 계획 - backend actuator health endpoint 인증 차단 해제
+
+## 수정 목적
+- 컨테이너 healthcheck가 정상 통과하도록 actuator health/info endpoint를 공개 허용한다.
+
+## 수정할 부분
+1. `SecurityConfig`
+   - `/actuator/health`, `/actuator/info` permitAll
+2. 검증
+   - backend 테스트
+   - compose 기동 후 backend health 상태 확인


### PR DESCRIPTION
## PR 작성 목적
backend healthcheck endpoint가 인증 차단으로 403을 반환해 container가 unhealthy 되는 문제를 해결합니다.

## 변경 내용
- `SecurityConfig`에서 다음 endpoint를 `permitAll`로 허용
  - `/actuator/health`
  - `/actuator/info`
- 계획 문서 추가
  - `plan/35_fix_backend_healthcheck_403.md`

## 테스트
- [x] backend `./gradlew test`

## 관련 이슈
- Closes #54
