### PR TITLE
fix(security): IPv6 loopback(::1) 허용 기본값 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Detailed specifications and architectural decisions can be found in the `spec/` 
    - 단일 리버스 프록시: `<proxy-ip>/32`
    - 금지 권장: `0.0.0.0/0`, `::/0` (모든 IP 신뢰)
 
+   VPN allowed subnets 기본값에는 IPv6 loopback(`::1/128`)이 포함됩니다.
+
    Generate a secure JWT secret:
    ```bash
    openssl rand -base64 32

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -46,7 +46,7 @@ cors:
 
 security:
   vpn:
-    allowed-subnets: 10.8.0.0/24,127.0.0.1/32,172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
+    allowed-subnets: 10.8.0.0/24,127.0.0.1/32,::1/128,172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
   network:
     trusted-proxies: ${TRUSTED_PROXY_SUBNETS:127.0.0.1/32,::1/128}
 

--- a/plan/36_fix_ipv6_loopback_ip_enforcement.md
+++ b/plan/36_fix_ipv6_loopback_ip_enforcement.md
@@ -1,0 +1,12 @@
+# #56 구현 계획 - IPv6 loopback 허용 누락 수정
+
+## 수정 목적
+- 내부 헬스체크가 IPv6 loopback(::1) 경로로 들어와도 IpEnforcementFilter에서 차단되지 않게 한다.
+
+## 수정할 부분
+1. `application.yml`의 `security.vpn.allowed-subnets` 기본값에 `::1/128` 추가
+2. `README`의 허용 대역 예시에 IPv6 loopback 반영
+
+## 테스트 계획
+- backend `./gradlew test`
+- compose 기동 후 backend health 상태 확인


### PR DESCRIPTION
## PR 작성 목적
IPv6 loopback(::1) 요청이 IpEnforcementFilter에서 차단되어 healthcheck가 실패하는 문제를 수정합니다.

## 변경 내용
- `security.vpn.allowed-subnets` 기본값에 `::1/128` 추가
- README에 IPv6 loopback 포함 사실 명시
- 계획 문서 추가: `plan/36_fix_ipv6_loopback_ip_enforcement.md`

## 테스트
- [x] backend `./gradlew test`

## 관련 이슈
- Closes #56
