### PR TITLE
fix(monitoring): backend healthcheck loopback을 127.0.0.1로 고정

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ docker-compose ps
 docker-compose logs --tail=100 nas-db nas-backend nas-frontend
 ```
 - `nas-db`: `pg_isready` 기반 healthy
-- `nas-backend`: `GET /actuator/health` 상태 기반 healthy
+- `nas-backend`: `GET /actuator/health` 상태 기반 healthy (IPv4 loopback 127.0.0.1 고정)
 - `nas-frontend`: nginx index 응답 기반 healthy
 - If Dockerfile/healthcheck was changed, run with `--build` to avoid stale image mismatch.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     volumes:
       - ${HOST_VOLUMES_PATH:-/Volumes}:/mnt/host_volumes:rw
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'"]
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/actuator/health | grep -q '\"status\":\"UP\"'"]
       interval: 15s
       timeout: 5s
       retries: 10

--- a/plan/37_fix_healthcheck_ipv4_loopback.md
+++ b/plan/37_fix_healthcheck_ipv4_loopback.md
@@ -1,0 +1,12 @@
+# #58 구현 계획 - backend healthcheck loopback 주소 고정
+
+## 수정 목적
+- localhost의 IPv6 해석 차이로 인한 healthcheck 403 실패를 제거한다.
+
+## 수정할 부분
+1. `docker-compose.yml` backend healthcheck URL을 `127.0.0.1`로 고정
+2. README에 loopback 주소 고정 이유 명시
+
+## 테스트 계획
+- docker-compose config 확인
+- backend 테스트


### PR DESCRIPTION
## PR 작성 목적
localhost의 IPv6 해석 차이로 인한 backend healthcheck 403 실패를 제거합니다.

## 변경 내용
- backend healthcheck URL을 `localhost` -> `127.0.0.1`로 고정
- README healthcheck 설명에 IPv4 loopback 고정 이유 반영
- 계획 문서 추가: `plan/37_fix_healthcheck_ipv4_loopback.md`

## 테스트
- [x] docker-compose config 렌더 확인
- [x] backend `./gradlew test`

## 관련 이슈
- Closes #58
