### PR TITLE
fix(monitoring): nas-frontend healthcheck 도구 부재 문제 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     ports:
       - "${FRONTEND_BIND_ADDRESS:-127.0.0.1}:80:80"
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://localhost/ >/dev/null 2>&1"]
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1/ >/dev/null"]
       interval: 20s
       timeout: 5s
       retries: 10

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,7 @@ RUN npm run build
 
 # Stage 2: Serve
 FROM nginx:alpine
+RUN apk add --no-cache curl
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/plan/38_fix_frontend_healthcheck_command.md
+++ b/plan/38_fix_frontend_healthcheck_command.md
@@ -1,0 +1,13 @@
+# #60 구현 계획 - nas-frontend healthcheck 명령 수정
+
+## 수정 목적
+- frontend 컨테이너가 healthcheck 도구 부재로 unhealthy 상태가 되지 않도록 보강한다.
+
+## 수정할 부분
+1. `frontend/Dockerfile` runtime 이미지에 curl 설치
+2. `docker-compose.yml` frontend healthcheck를 curl 기반으로 변경
+3. README healthcheck 설명 유지/정합성 확인
+
+## 테스트 계획
+- docker-compose config 확인
+- compose up 후 nas-frontend health status 확인


### PR DESCRIPTION
## PR 작성 목적
nas-frontend healthcheck가 도구 부재로 실패하는 문제를 해결합니다.

## 변경 내용
- frontend runtime 이미지에 `curl` 설치 (`frontend/Dockerfile`)
- compose frontend healthcheck를 curl 기반 probe로 변경
  - `curl -fsS http://127.0.0.1/ >/dev/null`
- 계획 문서 추가: `plan/38_fix_frontend_healthcheck_command.md`

## 테스트
- [x] docker-compose config 렌더 확인
- [x] compose up 후 nas-frontend health = healthy 확인

## 관련 이슈
- Closes #60
