### PR TITLE
fix(qa): smoke health check 경로를 actuator 정책에 맞게 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ docker-compose logs --tail=100 nas-db nas-backend nas-frontend
 ```bash
 bash scripts/smoke_e2e.sh
 ```
-This script builds/starts containers and validates key API paths (health, login fail/success, protected API access).
+This script builds/starts containers and validates key API paths (backend `/actuator/health`, login fail/success, protected API access).
 
 ### Backend Profile Notes
 - Production-safe defaults are in `application.yml` (SQL logs off).

--- a/plan/39_fix_smoke_healthcheck_path.md
+++ b/plan/39_fix_smoke_healthcheck_path.md
@@ -1,0 +1,12 @@
+# #62 구현 계획 - smoke_e2e health check 오탐 수정
+
+## 수정 목적
+- smoke script가 보안 정책과 맞지 않는 endpoint를 검사해 실패하는 문제를 제거한다.
+
+## 수정할 부분
+1. `scripts/smoke_e2e.sh` health check를 컨테이너 내부 `/actuator/health` 호출로 변경
+2. README 설명을 endpoint 정책과 일치하게 수정
+
+## 테스트 계획
+- `bash -n scripts/smoke_e2e.sh`
+- `bash scripts/smoke_e2e.sh` 재실행

--- a/scripts/smoke_e2e.sh
+++ b/scripts/smoke_e2e.sh
@@ -53,12 +53,12 @@ wait_healthy nas-backend
 wait_healthy nas-frontend
 
 echo "[3/5] health endpoint check"
-health=$(curl -fsS http://127.0.0.1/api/actuator/health)
+health=$(docker exec nas-backend sh -lc "curl -fsS http://127.0.0.1:8080/actuator/health")
 python3 - <<'PY' "$health"
 import json,sys
 obj=json.loads(sys.argv[1])
 assert obj.get('status')=='UP', obj
-print('  - /api/actuator/health status=UP')
+print('  - backend /actuator/health status=UP')
 PY
 
 echo "[4/5] login failure check"


### PR DESCRIPTION
## PR 작성 목적
smoke_e2e health check가 보안 정책과 맞지 않는 경로(`/api/actuator/health`)를 호출해 오탐 실패하는 문제를 수정합니다.

## 변경 내용
- smoke health check를 `docker exec nas-backend ... /actuator/health` 방식으로 변경
- README 설명을 실제 검증 경로와 정합화
- 계획 문서 추가: `plan/39_fix_smoke_healthcheck_path.md`

## 테스트
- [x] `bash -n scripts/smoke_e2e.sh`
- [x] `bash scripts/smoke_e2e.sh` -> `SMOKE_E2E_OK`

## 관련 이슈
- Closes #62
