### PR TITLE
perf(frontend): route lazy loading + vendor chunk 분리

### DIFF
--- a/frontend/src/app/providers/RouterProvider.tsx
+++ b/frontend/src/app/providers/RouterProvider.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, {Suspense} from 'react';
 import {BrowserRouter, Navigate, Outlet, Route, Routes} from 'react-router-dom';
 import {useAuthStore} from '@/entities/user/model/store';
-import {LoginPage} from '@/pages/login/LoginPage';
-import {DashboardPage} from '@/pages/dashboard/DashboardPage';
-import {AdminPage} from '@/pages/admin/AdminPage';
-import {ChangePasswordPage} from '@/pages/change-password/ChangePasswordPage';
 import {AppShell} from '@/shared/ui/AppShell';
+
+const LoginPage = React.lazy(() => import('@/pages/login/LoginPage').then(m => ({default: m.LoginPage})));
+const DashboardPage = React.lazy(() => import('@/pages/dashboard/DashboardPage').then(m => ({default: m.DashboardPage})));
+const AdminPage = React.lazy(() => import('@/pages/admin/AdminPage').then(m => ({default: m.AdminPage})));
+const ChangePasswordPage = React.lazy(() => import('@/pages/change-password/ChangePasswordPage').then(m => ({default: m.ChangePasswordPage})));
 
 // Protected Route Wrapper
 const RequireAuth: React.FC = () => {
@@ -46,7 +47,8 @@ const RedirectIfAuthenticated: React.FC = () => {
 
 export const AppRouter: React.FC = () => {
   return (
-      <BrowserRouter>
+    <BrowserRouter>
+      <Suspense fallback={null}>
         <Routes>
           <Route element={<RedirectIfAuthenticated/>}>
             <Route path="/login" element={<LoginPage/>}/>
@@ -64,6 +66,7 @@ export const AppRouter: React.FC = () => {
             </Route>
           </Route>
         </Routes>
-      </BrowserRouter>
+      </Suspense>
+    </BrowserRouter>
   );
 };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,6 +20,22 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id: string) {
+          if (!id.includes('node_modules')) return;
+          if (id.includes('/react/') || id.includes('/react-dom/') || id.includes('/react-router-dom/')) {
+            return 'react';
+          }
+          if (id.includes('/@mui/') || id.includes('/@emotion/')) {
+            return 'mui';
+          }
+          return 'vendor';
+        },
+      },
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/plan/40_frontend_chunk_splitting.md
+++ b/plan/40_frontend_chunk_splitting.md
@@ -1,0 +1,13 @@
+# #64 구현 계획 - Frontend 번들 청크 분리
+
+## 수정 목적
+- 초기 번들 크기 경고를 완화하고 로딩/캐시 효율을 개선한다.
+
+## 수정할 부분
+1. Router에서 페이지 컴포넌트 lazy loading 적용
+2. Vite build.rollupOptions.output.manualChunks로 vendor 분리
+3. 빌드 결과(청크 크기/경고) 확인
+
+## 테스트 계획
+- `npm run build`
+- 변경 전/후 번들 출력 비교


### PR DESCRIPTION
## PR 작성 목적
프론트엔드 빌드 시 메인 청크 500kB 초과 경고를 완화하고 초기 로딩 효율을 개선합니다.

## 변경 내용
- `RouterProvider`에 페이지 라우트 lazy loading 적용
- `vite.config.ts`에 `manualChunks` 함수 추가
  - react/mui/vendor 청크 분리
- 계획 문서 추가: `plan/40_frontend_chunk_splitting.md`

## 테스트
- [x] `npm run build`
- [x] 대형 단일 청크 경고 해소 확인

## 관련 이슈
- Closes #64
