### PR TITLE
fix(security): frontend axios high 취약점 패치

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@mui/icons-material": "^7.3.7",
         "@mui/material": "^7.3.7",
         "@tanstack/react-query": "^5.90.16",
-        "axios": "^1.13.2",
+        "axios": "^1.13.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
@@ -2463,13 +2463,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.7",
     "@tanstack/react-query": "^5.90.16",
-    "axios": "^1.13.2",
+    "axios": "^1.13.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.12.0",

--- a/plan/41_patch_axios_vulnerability.md
+++ b/plan/41_patch_axios_vulnerability.md
@@ -1,0 +1,12 @@
+# #66 구현 계획 - axios 취약점 패치
+
+## 수정 목적
+- npm audit high 취약점(GHSA-43fc-jf86-j433)을 제거한다.
+
+## 수정할 부분
+1. frontend axios dependency를 패치 버전으로 업그레이드
+2. package-lock.json 갱신
+
+## 테스트 계획
+- `npm run build`
+- `npm audit --omit=dev`


### PR DESCRIPTION
## PR 작성 목적
frontend 의존성에서 보고된 axios high 취약점(GHSA-43fc-jf86-j433)을 제거합니다.

## 변경 내용
- axios 최신 패치 버전으로 업데이트
- lockfile 갱신
- 계획 문서 추가: `plan/41_patch_axios_vulnerability.md`

## 테스트
- [x] `npm run build`
- [x] `npm audit --omit=dev` (high/critical 0)

## 관련 이슈
- Closes #66
