### PR TITLE
ci: PR/main 품질 게이트 자동화(workflow) 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  backend-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: gradle
+
+      - name: Run backend tests
+        run: ./gradlew test --no-daemon
+
+  frontend-build-audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+  smoke-e2e:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [backend-test, frontend-build-audit]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create .env for smoke
+        run: |
+          cat > .env << 'EOF'
+          APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD=ChangeMe_123!
+          JWT_SECRET=QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo0MTIzNDU2Nzg5MDEyMw==
+          WG_HOST=127.0.0.1
+          WG_EASY_VERSION=15
+          WG_PASSWORD_HASH=$2a$10$abcdefghijklmnopqrstuv1234567890abcdefghiJKLMNO
+          NAS_USER=nas_user
+          NAS_PASSWORD=nas_password
+          NAS_DB=nas_db
+          TRUSTED_PROXY_SUBNETS=127.0.0.1/32,::1/128
+          FRONTEND_BIND_ADDRESS=127.0.0.1
+          EOF
+
+      - name: Run smoke E2E
+        run: bash scripts/smoke_e2e.sh

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ bash scripts/smoke_e2e.sh
 ```
 This script builds/starts containers and validates key API paths (backend `/actuator/health`, login fail/success, protected API access).
 
+### CI Quality Gates
+- Pull Request / Push(main):
+  - backend `./gradlew test`
+  - frontend `npm ci && npm run build`
+  - frontend production dependency audit `npm audit --omit=dev --audit-level=high`
+- Push(main):
+  - `bash scripts/smoke_e2e.sh`
+
 ### Backend Profile Notes
 - Production-safe defaults are in `application.yml` (SQL logs off).
 - For local debugging with SQL logs enabled, use dev profile:

--- a/plan/42_ci_quality_gates.md
+++ b/plan/42_ci_quality_gates.md
@@ -1,0 +1,14 @@
+# #68 구현 계획 - CI 품질 게이트 자동화
+
+## 수정 목적
+- 수동 품질 점검(빌드/테스트/감사/스모크)을 CI로 자동화한다.
+
+## 수정할 부분
+1. `.github/workflows/ci.yml` 추가
+   - PR/push: backend test, frontend build, frontend audit
+   - main push: smoke_e2e
+2. README에 CI 검증 항목/트리거 설명 추가
+
+## 테스트 계획
+- workflow YAML 문법 검토
+- 로컬에서 backend/frontend/smoke 명령 재검증


### PR DESCRIPTION
## PR 작성 목적
수동으로 반복하던 검증 루프를 CI 품질 게이트로 자동화합니다.

## 변경 내용
- `.github/workflows/ci.yml` 추가
  - PR/push(main): backend test, frontend build, frontend audit
  - push(main): smoke E2E(`scripts/smoke_e2e.sh`)
- README에 CI Quality Gates 섹션 추가
- 계획 문서 추가: `plan/42_ci_quality_gates.md`

## 테스트
- [x] backend `./gradlew test`
- [x] frontend `npm ci && npm run build`
- [x] frontend `npm audit --omit=dev --audit-level=high`
- [x] `bash scripts/smoke_e2e.sh` (`SMOKE_E2E_OK`)

## 관련 이슈
- Closes #68
