### PR TITLE
feat(qa): 모든 backend API 경로 자동 discovery 스모크 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ docker-compose logs --tail=100 nas-db nas-backend nas-frontend
 ```bash
 bash scripts/smoke_e2e.sh
 ```
-This script builds/starts containers and validates key API paths (backend `/actuator/health`, login fail/success, protected API access).
+This script builds/starts containers, validates core auth/health paths, and then checks all discovered backend API routes (controller annotation 기반 자동 수집) for non-404/non-5xx reachability.
 
 ### CI Quality Gates
 - Pull Request / Push(main):

--- a/plan/43_smoke_all_routes_auto_discovery.md
+++ b/plan/43_smoke_all_routes_auto_discovery.md
@@ -1,0 +1,15 @@
+# #70 구현 계획 - 모든 API 경로 스모크 자동 커버
+
+## 수정 목적
+- 스모크 테스트를 핵심 경로 중심에서 전체 API 경로 커버로 확장한다.
+- PR에서 신규 API가 생기면 별도 수동 반영 없이 자동으로 스모크 대상에 포함되게 한다.
+
+## 수정할 부분
+1. Controller annotation 기반 route discovery 스크립트 추가
+2. `scripts/smoke_e2e.sh`에 전체 route reachability 검증 단계 추가
+3. README에 전체 경로 자동 커버 정책 명시
+
+## 테스트 계획
+- `bash scripts/smoke_e2e.sh` 실행
+- discovery 결과에 신규/기존 API가 포함되는지 확인
+- 404/5xx 회귀 감지 동작 확인

--- a/scripts/discover_api_routes.py
+++ b/scripts/discover_api_routes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "backend" / "src" / "main" / "java"
+
+CLASS_REQ_RE = re.compile(r"@RequestMapping\(([^)]*)\)", re.MULTILINE)
+METHOD_RE = re.compile(r"@(GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping)\(([^)]*)\)", re.MULTILINE)
+STRING_RE = re.compile(r'"([^"]+)"')
+
+HTTP_MAP = {
+    "GetMapping": "GET",
+    "PostMapping": "POST",
+    "PutMapping": "PUT",
+    "DeleteMapping": "DELETE",
+    "PatchMapping": "PATCH",
+}
+
+
+def parse_paths(arg_text: str):
+    vals = STRING_RE.findall(arg_text)
+    if not vals:
+        return [""]
+    # first string literal is enough for current project style
+    return [vals[0]]
+
+
+routes = []
+for file in SRC.rglob("*Controller.java"):
+    text = file.read_text(encoding="utf-8")
+    class_base = ""
+    cm = CLASS_REQ_RE.search(text)
+    if cm:
+        class_paths = parse_paths(cm.group(1))
+        class_base = class_paths[0]
+
+    for mm in METHOD_RE.finditer(text):
+        ann, args = mm.groups()
+        method = HTTP_MAP[ann]
+        method_paths = parse_paths(args)
+        sub = method_paths[0]
+        full = (class_base.rstrip("/") + "/" + sub.lstrip("/")).replace("//", "/")
+        if not full.startswith("/"):
+            full = "/" + full
+        routes.append({
+            "method": method,
+            "path": full,
+            "source": str(file.relative_to(ROOT)),
+        })
+
+# dedupe
+uniq = {(r["method"], r["path"]): r for r in routes}
+out = [uniq[k] for k in sorted(uniq.keys())]
+print(json.dumps(out, ensure_ascii=False))


### PR DESCRIPTION
## PR 작성 목적
스모크 테스트를 핵심 경로 중심에서 전체 API 경로 자동 커버 방식으로 확장합니다.

## 변경 내용
- `scripts/discover_api_routes.py` 추가
  - Controller annotation 기반으로 backend API route 자동 수집
- `scripts/smoke_e2e.sh` 확장
  - [6/6] 단계에서 discovery된 모든 route reachability 검증
  - 404/5xx 및 비허용 응답 감지 시 실패
- README 스모크 설명을 자동 커버 정책으로 갱신
- 계획 문서 추가: `plan/43_smoke_all_routes_auto_discovery.md`

## 테스트
- [x] `python3 scripts/discover_api_routes.py` (14 routes)
- [x] `bash scripts/smoke_e2e.sh` (`SMOKE_E2E_OK`)

## 관련 이슈
- Closes #70
