### PR TITLE
chore(qa): route discovery parser 정밀도 고도화

### DIFF
--- a/plan/44_route_discovery_parser_hardening.md
+++ b/plan/44_route_discovery_parser_hardening.md
@@ -1,0 +1,13 @@
+# #72 구현 계획 - route discovery 파서 정밀도 고도화
+
+## 수정 목적
+- annotation 표기 변형(value/path/배열)에서도 API route discovery 누락을 방지한다.
+
+## 수정할 부분
+1. `discover_api_routes.py` 파싱 로직 개선
+2. value/path/직접 문자열 패턴을 모두 지원
+3. 다중 path는 전부 route 후보로 반영
+
+## 테스트 계획
+- discovery 결과 route 수/경로 출력 검증
+- smoke_e2e 전체 경로 체크 통과 확인


### PR DESCRIPTION
## PR 작성 목적
API route discovery 파서의 정밀도를 높여 annotation 변형에서도 스모크 커버 누락을 줄입니다.

## 변경 내용
- `discover_api_routes.py` 파싱 로직 고도화
  - `value=` / `path=` 속성 파싱 지원
  - 배열/다중 path 문자열 처리 지원
  - class/method 다중 경로 조합 생성
- 계획 문서 추가: `plan/44_route_discovery_parser_hardening.md`

## 테스트
- [x] `python3 scripts/discover_api_routes.py` (14 routes)
- [x] `bash scripts/smoke_e2e.sh` (`SMOKE_E2E_OK`)

## 관련 이슈
- Closes #72
