### PR TITLE
chore(qa): no-arg/multiline mapping annotation route discovery 지원

### DIFF
--- a/plan/45_route_discovery_noarg_multiline.md
+++ b/plan/45_route_discovery_noarg_multiline.md
@@ -1,0 +1,13 @@
+# #74 구현 계획 - no-arg/dynamic annotation 파싱 보강
+
+## 수정 목적
+- route discovery가 괄호 없는 mapping annotation과 다중라인 인자에서도 누락 없이 동작하게 한다.
+
+## 수정할 부분
+1. discover_api_routes.py의 메서드 annotation 파서 개선
+2. @GetMapping/@PostMapping 등 no-arg 표기 처리
+3. smoke_e2e 재실행
+
+## 테스트 계획
+- discovery 실행 결과 확인
+- smoke_e2e 통과 확인

--- a/scripts/discover_api_routes.py
+++ b/scripts/discover_api_routes.py
@@ -6,10 +6,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "backend" / "src" / "main" / "java"
 
-CLASS_REQ_RE = re.compile(r"@RequestMapping\(([^)]*)\)", re.MULTILINE)
-METHOD_RE = re.compile(r"@(GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping)\(([^)]*)\)", re.MULTILINE)
-STRING_RE = re.compile(r'"([^"]+)"')
-PATH_ATTR_RE = re.compile(r"(?:value|path)\s*=\s*\{?([^}]*)\}?")
+CLASS_REQ_RE = re.compile(r"@RequestMapping\((.*?)\)", re.DOTALL)
+METHOD_RE = re.compile(r"@(GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping)(?:\((.*?)\))?", re.DOTALL)
+STRING_RE = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"')
+PATH_ATTR_RE = re.compile(r"(?:value|path)\s*=\s*\{?(.*?)\}?$", re.DOTALL)
 
 HTTP_MAP = {
     "GetMapping": "GET",
@@ -25,40 +25,47 @@ def parse_paths(arg_text: str):
     if not arg_text:
         return [""]
 
-    m = PATH_ATTR_RE.search(arg_text)
-    if m:
-        vals = STRING_RE.findall(m.group(1))
-        return vals or [""]
+    # normalize trailing commas/spaces from multiline annotations
+    normalized = re.sub(r"\s+", " ", arg_text).strip().rstrip(",")
 
-    vals = STRING_RE.findall(arg_text)
+    # value/path named attribute first
+    m = PATH_ATTR_RE.search(normalized)
+    target = m.group(1) if m else normalized
+
+    vals = STRING_RE.findall(target)
+    vals = [v.encode("utf-8").decode("unicode_escape") for v in vals]
     return vals or [""]
 
 
 routes = []
 for file in SRC.rglob("*Controller.java"):
     text = file.read_text(encoding="utf-8")
-    class_base = ""
-    cm = CLASS_REQ_RE.search(text)
+
     class_paths = [""]
+    cm = CLASS_REQ_RE.search(text)
     if cm:
         class_paths = parse_paths(cm.group(1))
 
     for mm in METHOD_RE.finditer(text):
         ann, args = mm.groups()
         method = HTTP_MAP[ann]
-        method_paths = parse_paths(args)
+        method_paths = parse_paths(args or "")
+
         for class_base in class_paths:
             for sub in method_paths:
                 full = (class_base.rstrip("/") + "/" + sub.lstrip("/")).replace("//", "/")
                 if not full.startswith("/"):
                     full = "/" + full
-                routes.append({
-                    "method": method,
-                    "path": full,
-                    "source": str(file.relative_to(ROOT)),
-                })
+                if len(full) > 1:
+                    full = full.rstrip("/")
+                routes.append(
+                    {
+                        "method": method,
+                        "path": full,
+                        "source": str(file.relative_to(ROOT)),
+                    }
+                )
 
-# dedupe
 uniq = {(r["method"], r["path"]): r for r in routes}
 out = [uniq[k] for k in sorted(uniq.keys())]
 print(json.dumps(out, ensure_ascii=False))


### PR DESCRIPTION
## PR 작성 목적
route discovery의 남은 사각지대(no-arg mapping, multiline annotation)를 보완해 스모크 자동 커버 신뢰도를 높입니다.

## 변경 내용
- `discover_api_routes.py` 개선
  - `@GetMapping`(괄호 없는 형태) 지원
  - multiline annotation 인자 파싱 안정화
  - trailing slash 정규화
- 계획 문서 추가: `plan/45_route_discovery_noarg_multiline.md`

## 테스트
- [x] `python3 scripts/discover_api_routes.py` (17 method-path routes)
- [x] `bash scripts/smoke_e2e.sh` (`SMOKE_E2E_OK`)

## 관련 이슈
- Closes #74
