### PR TITLE
feat(frontend): lazy admin widgets + standardized api error/retry + optimistic file actions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,19 @@ import {AppRouter} from '@/app/providers/RouterProvider';
 import {AppThemeProvider} from '@/app/providers/ThemeProvider';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {NotificationSnackbar} from '@/shared/ui/NotificationSnackbar';
+import {shouldRetryRequest} from '@/shared/api/axios';
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
-      retry: 1,
+      retry: (failureCount, error: any) => {
+        if (failureCount >= 2) return false;
+        const status = error?.response?.status as number | undefined;
+        const method = error?.config?.method as string | undefined;
+        return shouldRetryRequest(status, method);
+      },
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 5000),
     },
   },
 });

--- a/frontend/src/features/admin-dashboard/ui/AdminDashboard.tsx
+++ b/frontend/src/features/admin-dashboard/ui/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {Suspense, useState} from 'react';
 import {
   Box,
   Button,
@@ -15,9 +15,10 @@ import {
   TextField,
   Typography
 } from '@mui/material';
-import {SystemHealthWidget} from '@/widgets/system-health/ui/SystemHealthWidget';
-import {UserTable} from '@/widgets/user-table/ui/UserTable';
-import {AuditLogTable} from '@/widgets/audit-log-table/ui/AuditLogTable';
+
+const SystemHealthWidget = React.lazy(() => import('@/widgets/system-health/ui/SystemHealthWidget').then(m => ({default: m.SystemHealthWidget})));
+const UserTable = React.lazy(() => import('@/widgets/user-table/ui/UserTable').then(m => ({default: m.UserTable})));
+const AuditLogTable = React.lazy(() => import('@/widgets/audit-log-table/ui/AuditLogTable').then(m => ({default: m.AuditLogTable})));
 import {useSystemHealth} from '@/entities/system/model/useSystemHealth';
 import {useUserMutations, useUsers} from '@/entities/user/model/useUsers';
 import {useAuditLogs} from '@/entities/audit/model/useAuditLogs';
@@ -121,36 +122,38 @@ export const AdminDashboard: React.FC = () => {
           </Tabs>
         </Box>
 
-        {tab === 0 && (
-            <SystemHealthWidget data={healthData} isLoading={isHealthLoading}/>
-        )}
+        <Suspense fallback={<Box sx={{display: 'flex', justifyContent: 'center', p: 4}}><CircularProgress/></Box>}>
+          {tab === 0 && (
+              <SystemHealthWidget data={healthData} isLoading={isHealthLoading}/>
+          )}
 
-        {tab === 1 && (
-            isUsersLoading ? (
-                <Box sx={{display: 'flex', justifyContent: 'center', p: 4}}>
-                  <CircularProgress/>
-                </Box>
-            ) : usersData && (
-                <>
-                  <UserTable users={usersData} onAddUser={() => setIsUserModalOpen(true)}/>
-                  <CreateUserModal
-                      open={isUserModalOpen}
-                      onClose={() => setIsUserModalOpen(false)}
-                      onCreate={handleCreateUser}
-                  />
-                </>
-            )
-        )}
+          {tab === 1 && (
+              isUsersLoading ? (
+                  <Box sx={{display: 'flex', justifyContent: 'center', p: 4}}>
+                    <CircularProgress/>
+                  </Box>
+              ) : usersData && (
+                  <>
+                    <UserTable users={usersData} onAddUser={() => setIsUserModalOpen(true)}/>
+                    <CreateUserModal
+                        open={isUserModalOpen}
+                        onClose={() => setIsUserModalOpen(false)}
+                        onCreate={handleCreateUser}
+                    />
+                  </>
+              )
+          )}
 
-        {tab === 2 && (
-            isAuditLoading ? (
-                <Box sx={{display: 'flex', justifyContent: 'center', p: 4}}>
-                  <CircularProgress/>
-                </Box>
-            ) : auditLogs && (
-                <AuditLogTable logs={auditLogs}/>
-            )
-        )}
+          {tab === 2 && (
+              isAuditLoading ? (
+                  <Box sx={{display: 'flex', justifyContent: 'center', p: 4}}>
+                    <CircularProgress/>
+                  </Box>
+              ) : auditLogs && (
+                  <AuditLogTable logs={auditLogs}/>
+              )
+          )}
+        </Suspense>
       </Box>
   );
 };

--- a/frontend/src/shared/model/taskEvents.ts
+++ b/frontend/src/shared/model/taskEvents.ts
@@ -1,0 +1,20 @@
+export type FileTaskType = 'file.delete' | 'file.upload' | 'file.move';
+
+export interface FileTaskPayload {
+  type: FileTaskType;
+  count?: number;
+  fileName?: string;
+  sourcePath?: string;
+  destinationPath?: string;
+}
+
+export const buildTaskLabel = (payload: FileTaskPayload): string => {
+  switch (payload.type) {
+    case 'file.delete':
+      return `Delete ${payload.count ?? 0} file(s)`;
+    case 'file.upload':
+      return `Upload ${payload.fileName ?? 'file'}`;
+    case 'file.move':
+      return `Move ${payload.sourcePath ?? ''} -> ${payload.destinationPath ?? ''}`;
+  }
+};

--- a/frontend/src/shared/model/useTaskCenterStore.ts
+++ b/frontend/src/shared/model/useTaskCenterStore.ts
@@ -1,4 +1,5 @@
 import {create} from 'zustand';
+import {buildTaskLabel, type FileTaskPayload} from './taskEvents';
 
 export type TaskStatus = 'running' | 'success' | 'failed';
 
@@ -13,7 +14,7 @@ export interface TaskItem {
 
 interface TaskCenterState {
   tasks: TaskItem[];
-  startTask: (label: string) => string;
+  startTask: (task: string | FileTaskPayload) => string;
   completeTask: (id: string) => void;
   failTask: (id: string, errorMessage?: string) => void;
   clearFinished: () => void;
@@ -21,8 +22,9 @@ interface TaskCenterState {
 
 export const useTaskCenterStore = create<TaskCenterState>((set) => ({
   tasks: [],
-  startTask: (label) => {
+  startTask: (taskInput) => {
     const id = crypto.randomUUID();
+    const label = typeof taskInput === 'string' ? taskInput : buildTaskLabel(taskInput);
     const task: TaskItem = {id, label, status: 'running', startedAt: Date.now()};
     set((state) => ({
       tasks: [task, ...state.tasks].slice(0, 30),

--- a/plan/49_frontend_round3_remaining_points.md
+++ b/plan/49_frontend_round3_remaining_points.md
@@ -1,0 +1,14 @@
+# #89 #90 #91 #92 구현 계획
+
+## 목표
+- Frontend 남은 진단 포인트(성능/안정성/아키텍처)를 일괄 개선한다.
+
+## 변경
+1. MUI 관련 위젯 lazy loading으로 초기 청크 부담 완화 (#89)
+2. axios 에러 표준 처리(401/403/429/5xx) + query retry 정책 명확화 (#90)
+3. 파일 삭제/이동 optimistic update + rollback 적용 (#91)
+4. TaskCenter 이벤트 계약 typed payload 도입 (#92)
+
+## 테스트
+- frontend build
+- smoke_e2e


### PR DESCRIPTION
## PR 작성 목적
frontend 남은 진단 포인트(#89 #90 #91 #92)를 일괄 반영합니다.

## 변경 내용
### Performance (#89)
- AdminDashboard 위젯(SystemHealth/UserTable/AuditLogTable) lazy loading 적용
- 초기 탭 로딩 부담 완화(탭별 청크 분리)

### Reliability / Security (#90)
- axios interceptor 상태코드별 표준 처리 추가
  - 401: logout + 재로그인 안내
  - 403/429: 사용자 메시지 표준화
- Query retry 정책 고도화
  - GET/HEAD/OPTIONS + 429/5xx 중심 재시도
  - exponential backoff 적용

### Reliability (#91)
- file delete/move에 optimistic update + rollback 도입
- 실패 시 캐시 스냅샷 복구

### Architecture (#92)
- TaskCenter 이벤트 계약 typed payload 도입
  - `taskEvents.ts` 추가
  - `startTask`가 string | typed payload 지원

## 테스트
- [x] frontend `npm run build`
- [~] smoke_e2e는 backend docker build 단계 장기대기 재관측(기존 known), 변경 영향은 프론트 레이어로 제한

## 관련 이슈
- Closes #89
- Closes #90
- Closes #91
- Closes #92
