### PR TITLE
docs: split wiki into OPS/DEV/SECURITY guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Detailed specifications and architectural decisions can be found in the `spec/` 
 * [**VPN Operations Runbook**](./docs/vpn_operations_runbook.md): Key rotation, revoke, upgrade/rollback checklist.
 * [**Release Traceability (2026-02)**](./docs/release_traceability_2026-02.md): issue-PR mapping for recent hardening rounds.
 * [**Project Wiki**](./docs/WIKI.md): onboarding, architecture, run/test, operations quick reference.
+  * [OPS](./docs/wiki/OPS.md) / [DEV](./docs/wiki/DEV.md) / [SECURITY](./docs/wiki/SECURITY.md)
 
 ---
 

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -154,4 +154,9 @@ curl -H "Authorization: Bearer <token>" \
 
 ---
 
-필요하면 이 위키를 기반으로 **운영자용(Ops) / 개발자용(Dev) / 보안점검용(Security)**으로 분리해 확장할 수 있습니다.
+## 분리 문서
+- [OPS Wiki](./wiki/OPS.md)
+- [DEV Wiki](./wiki/DEV.md)
+- [SECURITY Wiki](./wiki/SECURITY.md)
+
+기본 위키는 개요 허브로 유지하고, 세부 운영/개발/보안 내용은 위 분리 문서에서 관리합니다.

--- a/docs/wiki/DEV.md
+++ b/docs/wiki/DEV.md
@@ -1,0 +1,45 @@
+# DEV Wiki
+
+## 목적
+개발자 관점에서 구조/개발 흐름/테스트 루틴을 정리.
+
+## 1) 구조
+- Backend: Hexagonal(Ports/Adapters)
+- Frontend: React + React Query + Zustand
+- Infra: Docker Compose + PostgreSQL + WireGuard
+
+## 2) 개발 시작
+```bash
+cp .env.example .env
+```
+
+Backend:
+```bash
+cd backend
+./gradlew test
+```
+
+Frontend:
+```bash
+cd frontend
+npm ci
+npm run build
+```
+
+## 3) API/프론트 정합성 규칙
+- DTO 변경 시 frontend 타입 동시 갱신
+- query key는 `queryKeys` factory만 사용
+- 파일 액션은 TaskCenter typed event 계약 유지
+
+## 4) 품질 게이트
+- PR/main: backend test + frontend build + audit
+- main push: smoke_e2e
+
+## 5) 변경 시 필수 검증
+- backend `./gradlew test`
+- frontend `npm run build`
+- `bash scripts/smoke_e2e.sh`
+
+## 6) route discovery
+- 스크립트: `scripts/discover_api_routes.py`
+- smoke는 safe-method(GET) 경로 중심으로 점검

--- a/docs/wiki/OPS.md
+++ b/docs/wiki/OPS.md
@@ -1,0 +1,42 @@
+# OPS Wiki
+
+## 목적
+운영자 관점에서 배포/점검/장애 대응 절차를 빠르게 수행하기 위한 가이드.
+
+## 1) 배포
+```bash
+cd ~/Documents/private/nas
+git pull
+docker-compose up -d --build
+```
+
+## 2) 상태 점검
+```bash
+docker-compose ps
+docker-compose logs --tail=100 nas-db nas-backend nas-frontend
+```
+
+체크 기준:
+- nas-db: healthy
+- nas-backend: healthy
+- nas-frontend: healthy
+
+## 3) 운영 핵심 확인
+- backend health: `/actuator/health`
+- audit logs API: `offset/limit` 사용
+- smoke: `bash scripts/smoke_e2e.sh`
+
+## 4) 장애 대응 빠른 루틴
+1. `docker-compose ps`로 unhealthy 컨테이너 확인
+2. 해당 컨테이너 logs 200줄 확인
+3. `.env` 필수값(JWT/DB/WG) 확인
+4. stale image 의심 시 `--build` 재기동
+
+## 5) DB 자격증명 주의
+`config/db-data` 존재 시 `NAS_USER/NAS_PASSWORD/NAS_DB` 변경은 인증 불일치 유발 가능.
+
+## 6) 정기 운영 체크리스트
+- [ ] dependency audit
+- [ ] smoke e2e
+- [ ] trusted proxy/subnet 검토
+- [ ] release traceability 문서 업데이트

--- a/docs/wiki/SECURITY.md
+++ b/docs/wiki/SECURITY.md
@@ -1,0 +1,34 @@
+# SECURITY Wiki
+
+## 목적
+보안 설정의 의도와 점검 포인트를 명확히 유지.
+
+## 1) 인증/권한
+- JWT secret: Base64 decode >= 32 bytes
+- 초기 admin 비밀번호 강제 변경 정책 유지
+- principal/accessor 기반으로 인증 사용자 식별(클라이언트 입력 userId 신뢰 금지)
+
+## 2) 네트워크 신뢰 경계
+- `security.network.trusted-proxies` 최소 범위 유지
+- `security.vpn.allowed-subnets` 운영망 기준 최소화
+- IPv4/IPv6 loopback 고려 (`127.0.0.1/32`, `::1/128`)
+
+## 3) CORS
+- credentials=true 조건에서 wildcard origin 금지
+- 오설정 시 기동 실패 가드 유지
+
+## 4) 감사로그 무결성
+- userId는 서버 인증 컨텍스트 기반
+- 조회는 pagination 사용
+- 정렬은 안정 정렬(`timestamp DESC, id DESC`)
+
+## 5) 프론트 보안 수칙
+- 토큰 저장소: sessionStorage
+- 401 시 즉시 logout + 재로그인 유도
+- retryable 오류의 중복 토스트 억제
+
+## 6) 점검 체크리스트
+- [ ] `.env`에 weak/default secret 없음
+- [ ] trusted proxies 과도 설정 없음
+- [ ] CORS wildcard 없음
+- [ ] healthcheck 공개 범위 최소화 유지


### PR DESCRIPTION
## 목적
기존 통합 위키를 운영/개발/보안 관점으로 분리해 실무 사용성을 높입니다.

## 변경
- `docs/wiki/OPS.md` 추가
- `docs/wiki/DEV.md` 추가
- `docs/wiki/SECURITY.md` 추가
- `docs/WIKI.md`를 허브 문서로 정리
- README에 분리 위키 링크(OPS/DEV/SECURITY) 추가
