### PR TITLE
feat(frontend): drag-and-drop move/upload in file browser

### DIFF
--- a/plan/53_drag_drop_file_folder_management.md
+++ b/plan/53_drag_drop_file_folder_management.md
@@ -1,0 +1,33 @@
+# Plan 53 - Drag & Drop File/Folder Management
+
+## Goal
+관리 페이지에서 폴더/파일을 드래그 앤 드랍으로 이동/업로드할 수 있게 한다.
+
+## Scope
+1. 내부 이동 DnD
+   - 파일/폴더 항목을 드래그해서 디렉토리 항목 위에 드랍하면 이동
+   - 다중 선택 상태에서 드래그하면 선택 항목 전체 이동
+2. 외부 파일 업로드 DnD
+   - OS Finder에서 파일을 브라우저 파일영역으로 드랍하면 현재 디렉토리로 업로드
+
+## Non-Goal
+- 폴더 트리 UI 신설
+- 백엔드 API 신규 추가(기존 move/upload 재사용)
+
+## Design (minimal)
+- 기존 `moveFile`/`uploadFile` mutation 재사용
+- `FileTable`에 DnD 이벤트 추가(리스트/그리드 공통)
+- `FileBrowser`에서 DnD orchestration(경로 계산, 유효성, 업로드 루프)
+
+## Risk Review
+- 과도 설계 방지: 외부 라이브러리 미도입(HTML5 DnD)
+- 사이드이펙트: 기존 클릭/더블클릭/선택 동작 유지
+- 보안: 경로 생성은 기존 서버 검증을 따르고 클라이언트는 기본 guard만 수행
+
+## Tests
+- frontend build
+- 수동
+  - 단일 파일 drag -> 디렉토리 drop 이동
+  - 다중 선택 drag -> 디렉토리 drop 이동
+  - Finder 파일 drag -> 업로드
+  - 잘못된 드랍(자기 자신/비-디렉토리) 무시


### PR DESCRIPTION
## Summary
Admin 파일 브라우저에 Drag & Drop 기반 관리 기능을 추가했습니다.

- 내부 이동: 파일/폴더를 드래그해서 대상 폴더에 드랍하면 이동
- 다중 선택 이동: 선택된 여러 항목을 한 번에 드랍 이동
- 외부 업로드: Finder 파일을 브라우저 영역에 드랍 시 현재 폴더로 업로드

## Linked Issue
- Closes #105

## Plan
- Ref: `plan/53_drag_drop_file_folder_management.md`

## Why
사용자 관리 흐름을 클릭 중심에서 DnD 중심으로 확장해 파일 관리 속도와 사용성을 높이기 위함.

## Changes
### `FileTable`
- HTML5 DnD 이벤트 추가 (list/grid/mobile list)
- drag payload: 선택 항목(또는 단일 항목) 이름 목록
- 디렉토리 항목 drop target 처리 및 hover 표시

### `FileBrowser`
- DnD orchestration 추가
  - source/destination path 계산 후 기존 `moveFile` mutation 재사용
  - Finder file drop 시 기존 `uploadFile` mutation 재사용
- dropzone 안내 Alert 추가

## Quality / Review (Pn)
### P1
- 기존 move/upload API 재사용으로 아키텍처 일관성 유지
- 자기 자신 디렉토리로 드랍되는 케이스 기본 skip 처리

### P2
- 클릭/더블클릭/선택/컨텍스트 메뉴 동작과 공존
- 외부 라이브러리 미도입으로 복잡도 최소화

### P3
- 이후 대량 이동 시 task batching/aggregate notification 개선 가능

## Verification
- `frontend npm run build` ✅

## Side Effects Check
- 파일 액션 기존 훅(`useFileActions`)만 재사용, 백엔드/API 스펙 변경 없음
