### PR TITLE
feat(frontend): harden DnD UX with drag count and move confirm

### DIFF
--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -32,6 +32,7 @@ interface FileTableProps {
   onSelectionChange: (selected: Set<string>) => void;
   onContextMenu?: (event: React.MouseEvent, file: FileNode) => void;
   onDropToDirectory?: (sourceNames: string[], targetDirectoryName: string) => void;
+  onDragSelectionCountChange?: (count: number) => void;
 }
 
 const StyledTableRow = styled(TableRow)(({theme}) => ({
@@ -97,6 +98,7 @@ export const FileTable: React.FC<FileTableProps> = ({
                                                       onSelectionChange,
                                                       onContextMenu,
                                                       onDropToDirectory,
+                                                      onDragSelectionCountChange,
                                                     }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -134,9 +136,16 @@ export const FileTable: React.FC<FileTableProps> = ({
   };
 
   const handleDragStart = (event: React.DragEvent, file: FileNode) => {
-    const payload = JSON.stringify(getDraggedNames(file));
+    const names = getDraggedNames(file);
+    const payload = JSON.stringify(names);
     event.dataTransfer.setData('application/x-nas-file-names', payload);
     event.dataTransfer.effectAllowed = 'move';
+    onDragSelectionCountChange?.(names.length);
+  };
+
+  const handleDragEnd = () => {
+    setDragOverDir(null);
+    onDragSelectionCountChange?.(0);
   };
 
   const handleDragOverDirectory = (event: React.DragEvent, directoryName: string) => {
@@ -183,6 +192,7 @@ export const FileTable: React.FC<FileTableProps> = ({
                   <ListItemButton
                       draggable
                       onDragStart={(e) => handleDragStart(e, file)}
+                      onDragEnd={handleDragEnd}
                       onDragOver={(e) => file.type === 'DIRECTORY' && handleDragOverDirectory(e, file.name)}
                       onDragLeave={() => setDragOverDir(null)}
                       onDrop={(e) => file.type === 'DIRECTORY' && handleDropDirectory(e, file.name)}
@@ -241,6 +251,7 @@ export const FileTable: React.FC<FileTableProps> = ({
                         selected={isSelected}
                         draggable
                         onDragStart={(e) => handleDragStart(e, file)}
+                        onDragEnd={handleDragEnd}
                         onDragOver={(e) => file.type === 'DIRECTORY' && handleDragOverDirectory(e, file.name)}
                         onDragLeave={() => setDragOverDir(null)}
                         onDrop={(e) => file.type === 'DIRECTORY' && handleDropDirectory(e, file.name)}
@@ -318,6 +329,7 @@ export const FileTable: React.FC<FileTableProps> = ({
                       selected={isSelected}
                       draggable
                       onDragStart={(e) => handleDragStart(e, file)}
+                      onDragEnd={handleDragEnd}
                       onDragOver={(e) => file.type === 'DIRECTORY' && handleDragOverDirectory(e, file.name)}
                       onDragLeave={() => setDragOverDir(null)}
                       onDrop={(e) => file.type === 'DIRECTORY' && handleDropDirectory(e, file.name)}

--- a/plan/54_dnd_feedback_safety_hardening.md
+++ b/plan/54_dnd_feedback_safety_hardening.md
@@ -1,0 +1,26 @@
+# Plan 54 - DnD Feedback & Safety Hardening
+
+## Goal
+드래그 앤 드랍 파일 관리 UX를 강화해 실수 이동을 줄이고 현재 드래그 상태를 명확히 보여준다.
+
+## Scope
+1. 드래그 중 선택 항목 개수 표시(배지/안내)
+2. 폴더 드랍 시 이동 확인 모달 추가
+3. 확인 후에만 실제 move API 호출
+
+## Non-Goal
+- 백엔드 API 변경
+- 대규모 상태관리 리팩토링
+
+## Review
+- 과도 설계 방지: 기존 DnD 로직 위에 최소 상태만 추가
+- 기존 코드 재사용: moveFile mutation 그대로 사용
+- 사이드이펙트: 업로드 DnD/기존 선택/컨텍스트 메뉴 영향 확인
+
+## Tests
+- frontend build
+- 수동:
+  - drag 시작 시 카운트 안내 노출
+  - folder drop 시 확인 모달 노출
+  - 취소 시 이동 미발생
+  - 확인 시 이동 성공


### PR DESCRIPTION
## Summary
DnD 파일 이동 UX를 안전하게 보강했습니다.

- 드래그 시작 시 항목 개수 안내 표시
- 폴더 drop 시 즉시 이동하지 않고 확인 모달 표시
- 사용자 확인 후 기존 move mutation 수행

## Linked Issue
- Closes #107

## Plan
- Ref: `plan/54_dnd_feedback_safety_hardening.md`

## Why
드래그 이동의 실수 가능성을 줄이고, 현재 사용자가 무엇을 드래그 중인지 명확히 보여주기 위함.

## Changes
### FileTable
- drag selection count 콜백 추가
- drag start/end에서 count 전달
- 기존 drop-to-directory 로직 유지

### FileBrowser
- `draggingCount` 상태 추가 및 안내 Alert 노출
- `pendingMove` 상태 추가
- 폴더 drop 시 confirm dialog 표시
- 확인 시 move 실행, 취소 시 무시

## Pn Review
### P1
- 실수 이동 방지(확인 모달) 도입
- 기존 move API 재사용으로 아키텍처 일관성 유지

### P2
- 드래그 중 사용자 피드백 강화
- 취소 동작에서 사이드이펙트 없음

### P3
- 추후 대량 이동 시 단일 배치/요약 task로 확장 가능

## Verification
- `frontend npm run build` ✅
