### PR TITLE
feat(frontend): add image/video thumbnails in file browser

### DIFF
--- a/frontend/src/entities/file/ui/FileThumbnail.tsx
+++ b/frontend/src/entities/file/ui/FileThumbnail.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import {Box} from '@mui/material';
+import type {SxProps, Theme} from '@mui/material';
+import {API_URL} from '@/shared/api/axios';
+import {useAuthStore} from '@/entities/user/model/store';
+import {FileIcon} from './FileIcon';
+import {isImageFile, isVideoFile} from './mediaPreview';
+
+interface FileThumbnailProps {
+  name: string;
+  path: string;
+  size?: number;
+  sx?: SxProps<Theme>;
+}
+
+export const FileThumbnail: React.FC<FileThumbnailProps> = ({name, path, size = 28, sx}) => {
+  const [url, setUrl] = React.useState<string | null>(null);
+  const [failed, setFailed] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isImageFile(name) && !isVideoFile(name)) {
+      setUrl(null);
+      setFailed(true);
+      return;
+    }
+
+    const token = useAuthStore.getState().token;
+    if (!token) {
+      setFailed(true);
+      return;
+    }
+
+    const endpoint = isImageFile(name)
+      ? `${API_URL}/files/preview?path=${encodeURIComponent(path)}`
+      : `${API_URL}/files/download?path=${encodeURIComponent(path)}`;
+
+    let objectUrl: string | null = null;
+    const controller = new AbortController();
+
+    fetch(endpoint, {
+      method: 'GET',
+      headers: {Authorization: `Bearer ${token}`},
+      signal: controller.signal,
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`preview fetch failed: ${res.status}`);
+        return res.blob();
+      })
+      .then((blob) => {
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+        setFailed(false);
+      })
+      .catch(() => {
+        setFailed(true);
+      });
+
+    return () => {
+      controller.abort();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [name, path]);
+
+  if (failed || !url) {
+    return <FileIcon name={name} type="FILE" sx={{fontSize: size, ...sx}}/>;
+  }
+
+  if (isVideoFile(name)) {
+    return (
+      <Box
+        component="video"
+        src={url}
+        muted
+        playsInline
+        preload="metadata"
+        sx={{
+          width: size,
+          height: size,
+          borderRadius: '6px',
+          objectFit: 'cover',
+          backgroundColor: '#111',
+          ...sx,
+        }}
+      />
+    );
+  }
+
+  return (
+    <Box
+      component="img"
+      src={url}
+      alt={name}
+      sx={{
+        width: size,
+        height: size,
+        borderRadius: '6px',
+        objectFit: 'cover',
+        ...sx,
+      }}
+    />
+  );
+};

--- a/frontend/src/entities/file/ui/mediaPreview.ts
+++ b/frontend/src/entities/file/ui/mediaPreview.ts
@@ -1,0 +1,10 @@
+const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp']);
+const VIDEO_EXTENSIONS = new Set(['mp4', 'mov', 'm4v', 'webm', 'avi', 'mkv']);
+
+export const getExtension = (name: string): string => {
+  return name.split('.').pop()?.toLowerCase() ?? '';
+};
+
+export const isImageFile = (name: string): boolean => IMAGE_EXTENSIONS.has(getExtension(name));
+export const isVideoFile = (name: string): boolean => VIDEO_EXTENSIONS.has(getExtension(name));
+export const isPreviewableMedia = (name: string): boolean => isImageFile(name) || isVideoFile(name);

--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -21,6 +21,8 @@ import {
 import type {FileNode} from '@/entities/file/model/types';
 import {AppCard} from '@/shared/ui';
 import {FileIcon} from '@/entities/file/ui/FileIcon';
+import {FileThumbnail} from '@/entities/file/ui/FileThumbnail';
+import {isPreviewableMedia} from '@/entities/file/ui/mediaPreview';
 
 export type ViewMode = 'list' | 'grid';
 
@@ -209,7 +211,11 @@ export const FileTable: React.FC<FileTableProps> = ({
                       }}
                   >
                     <ListItemAvatar sx={{minWidth: 40, mr: 1}}>
-                      <FileIcon name={file.name} type={file.type}/>
+                      {file.type === 'FILE' && isPreviewableMedia(file.name) ? (
+                        <FileThumbnail name={file.name} path={file.path} size={28}/>
+                      ) : (
+                        <FileIcon name={file.name} type={file.type}/>
+                      )}
                     </ListItemAvatar>
                     <ListItemText
                         primary={file.name}
@@ -273,7 +279,11 @@ export const FileTable: React.FC<FileTableProps> = ({
                             size="small"
                         />
                       </Box>
-                      <FileIcon name={file.name} type={file.type} sx={{fontSize: 64, mb: 1}}/>
+                      {file.type === 'FILE' && isPreviewableMedia(file.name) ? (
+                        <FileThumbnail name={file.name} path={file.path} size={64} sx={{mb: 1}}/>
+                      ) : (
+                        <FileIcon name={file.name} type={file.type} sx={{fontSize: 64, mb: 1}}/>
+                      )}
                       <Typography
                           variant="body2"
                           align="center"
@@ -351,7 +361,11 @@ export const FileTable: React.FC<FileTableProps> = ({
                       />
                     </StyledTableCell>
                     <StyledTableCell>
-                      <FileIcon name={file.name} type={file.type}/>
+                      {file.type === 'FILE' && isPreviewableMedia(file.name) ? (
+                        <FileThumbnail name={file.name} path={file.path} size={28}/>
+                      ) : (
+                        <FileIcon name={file.name} type={file.type}/>
+                      )}
                     </StyledTableCell>
                     <StyledTableCell component="th" scope="row" sx={{fontWeight: 500}}>
                       {file.name}

--- a/plan/55_media_thumbnail_preview.md
+++ b/plan/55_media_thumbnail_preview.md
@@ -1,0 +1,30 @@
+# Plan 55 - Photo/Video Thumbnail Preview
+
+## Goal
+파일 브라우저에서 사진/동영상 파일에 대해 썸네일 미리보기를 제공한다.
+
+## Scope
+1. 이미지 파일: `/api/files/preview` 기반 썸네일 표시
+2. 동영상 파일: `/api/files/download` blob URL 기반 `<video>` 미리보기(무음/controls 없음)
+3. 리스트/그리드 공통 적용
+
+## Non-Goal
+- 백엔드 ffmpeg 기반 영상 썸네일 생성
+- 썸네일 캐시 서버 구조 변경
+
+## Design
+- 프론트에서 파일 확장자로 미리보기 가능 타입 판별
+- 인증은 fetch + Bearer 토큰으로 수행(기존 axios 글로벌 에러 토스트 오염 방지)
+- 실패 시 기존 FileIcon fallback
+
+## Risk Review
+- 과도성 방지: 최소 구현(기존 API 재사용)
+- 보안: 기존 인증 토큰 헤더 방식 유지
+- 사이드이펙트: preview fetch 실패해도 UI는 아이콘 fallback으로 안전
+
+## Tests
+- frontend build
+- 수동:
+  - jpg/png/webp 썸네일 노출
+  - mp4/mov 썸네일(첫 프레임) 노출
+  - 미지원 포맷은 기존 아이콘 유지


### PR DESCRIPTION
## Summary
사진/동영상 파일에 대해 파일 브라우저에서 썸네일 미리보기를 추가했습니다.

- 이미지: `/api/files/preview` 기반 썸네일
- 동영상: `/api/files/download` blob 기반 `<video>` 프레임 미리보기
- 실패 시 기존 파일 아이콘 fallback

## Linked Issue
- Closes #109

## Plan
- Ref: `plan/55_media_thumbnail_preview.md`

## Why
파일 목록에서 미디어를 빠르게 식별할 수 있어 관리 효율이 크게 올라갑니다.

## Changes
### New
- `frontend/src/entities/file/ui/mediaPreview.ts`
  - 이미지/동영상 확장자 판별 유틸
- `frontend/src/entities/file/ui/FileThumbnail.tsx`
  - 인증 Bearer 토큰 포함 fetch로 blob URL 생성
  - 이미지/동영상 렌더링 + fallback 처리

### Updated
- `frontend/src/widgets/file-table/ui/FileTable.tsx`
  - list/grid/table 뷰에서 미디어 파일에 `FileThumbnail` 적용
  - 비미디어/실패 시 기존 `FileIcon` 유지

## Pn Review
### P1
- 인증 유지: token 기반 fetch 헤더 사용
- 실패 안전성: preview 실패 시 UI fallback으로 기능 지속

### P2
- 기존 아키텍처 재사용: backend preview/download API 활용
- 전역 axios 에러 토스트 오염 방지(fetch 별도 사용)

### P3
- 향후 최적화: 클라이언트 썸네일 캐시/가상스크롤 대응 가능

## Validation
- `frontend npm run build` ✅

## Side Effect Check
- 선택/이동/컨텍스트 메뉴 이벤트 경로는 변경하지 않음
- 렌더 계층에서만 썸네일 표시 확장
