### PR TITLE
feat(frontend): DnD collision guard + stronger highlight + batch summary

### DIFF
--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -207,7 +207,8 @@ export const FileTable: React.FC<FileTableProps> = ({
                         borderBottom:
                             index !== files.length - 1 ? `1px solid ${theme.palette.divider}` : 'none',
                         py: 1.5,
-                        backgroundColor: dragOverDir === file.name ? 'action.hover' : undefined,
+                        backgroundColor: dragOverDir === file.name ? `${theme.palette.primary.main}22` : undefined,
+                        outline: dragOverDir === file.name ? `2px dashed ${theme.palette.primary.main}` : undefined,
                       }}
                   >
                     <ListItemAvatar sx={{minWidth: 40, mr: 1}}>
@@ -267,7 +268,11 @@ export const FileTable: React.FC<FileTableProps> = ({
                           e.preventDefault();
                           onContextMenu?.(e, file);
                         }}
-                        sx={dragOverDir === file.name ? {outline: `2px dashed ${theme.palette.primary.main}`} : undefined}
+                        sx={dragOverDir === file.name ? {
+                          outline: `2px dashed ${theme.palette.primary.main}`,
+                          backgroundColor: `${theme.palette.primary.main}14`,
+                          boxShadow: `0 0 0 2px ${theme.palette.primary.main}22 inset`
+                        } : undefined}
                     >
                       <Box sx={{position: 'absolute', top: 8, left: 8}}>
                         <Checkbox
@@ -349,7 +354,10 @@ export const FileTable: React.FC<FileTableProps> = ({
                         e.preventDefault();
                         onContextMenu?.(e, file);
                       }}
-                      sx={dragOverDir === file.name ? {outline: `2px dashed ${theme.palette.primary.main}`} : undefined}
+                      sx={dragOverDir === file.name ? {
+                        outline: `2px dashed ${theme.palette.primary.main}`,
+                        backgroundColor: `${theme.palette.primary.main}14`
+                      } : undefined}
                   >
                     <StyledTableCell padding="checkbox">
                       <Checkbox

--- a/plan/56_dnd_collision_highlight_batch.md
+++ b/plan/56_dnd_collision_highlight_batch.md
@@ -1,0 +1,31 @@
+# Plan 56 - DnD Collision Guard + Highlight + Batch Summary
+
+## Goal
+드래그 앤 드랍 이동 UX를 다음 단계로 개선한다.
+
+## Scope
+1. 이동 충돌 사전 감지
+   - drop 대상 디렉토리에 같은 이름이 이미 있으면 사전 감지
+   - 충돌 파일은 건너뛰고 사용자에게 요약 안내
+2. 대상 폴더 하이라이트 강화
+   - drag-over 폴더에 더 명확한 시각 피드백 제공
+3. 대량 이동 요약 Task 처리
+   - 다건 이동을 단일 Task로 집계
+   - 성공/실패 요약 알림 제공
+
+## Non-Goal
+- 백엔드 API 변경
+- 새 인프라 도입
+
+## Complexity / Maintenance Review
+- 과도성 방지: 기존 move/list API 재사용
+- 유지보수성: 배치 이동 로직을 useFileActions로 모아 재사용 가능성 확보
+- 성능: 대상 디렉토리 목록 1회 조회로 충돌 검사
+- 보안: 기존 인증/인가 경계 유지 (클라이언트는 UX 사전가드)
+
+## Tests
+- frontend build
+- 수동:
+  - 충돌 있는 파일 drag-drop 시 충돌 안내 + non-conflict만 이동
+  - drag-over 하이라이트 강화 확인
+  - 다건 이동 시 단일 Task/요약 메시지 확인


### PR DESCRIPTION
## Summary
DnD 이동 UX의 다음 단계(충돌 사전감지/하이라이트 강화/배치 요약)를 구현했습니다.

## Linked Issue
- Closes #111

## Plan
- Ref: `plan/56_dnd_collision_highlight_batch.md`

## Changes
1. 충돌 사전 감지
- drop 대상 디렉토리 목록을 1회 조회
- 동일 파일명 충돌 항목은 이동 대상에서 제외
- 충돌 건수 요약 알림 표시

2. 하이라이트 강화
- drag-over 대상 폴더에 색상 + dashed outline + 강조 표시 강화

3. 대량 이동 요약 Task
- `useFileActions.moveFilesBatch` 추가
- 다건 이동을 단일 task로 처리
- 성공/실패 요약 notification 제공

## Pn Review
### P1
- 충돌 파일 덮어쓰기/오작동 방지
- 기존 인증/API 경계 유지

### P2
- 이동 UX 피드백 강화
- 배치 처리로 task/알림 노이즈 감소

### P3
- 추후 서버 배치 이동 API로 확장 여지 유지

## Validation
- `frontend npm run build` ✅

## Side Effects
- 기존 단건 move API는 유지
- DnD 경로에서만 배치 처리 사용
