### PR TITLE
feat(frontend): thumbnail round2 with skeleton/lazy/video-hover

### DIFF
--- a/plan/57_thumbnail_ux_performance_round2.md
+++ b/plan/57_thumbnail_ux_performance_round2.md
@@ -1,0 +1,23 @@
+# Plan 57 - Thumbnail UX/Performance Round 2
+
+## Goal
+썸네일 기능 2차 고도화: 로딩 skeleton, 지연 로딩(뷰포트 진입 시 fetch), 동영상 hover 미리보기.
+
+## Scope
+1. FileThumbnail 로딩 skeleton 표시
+2. IntersectionObserver 기반 lazy fetch
+3. video 썸네일 hover 시 자동 재생(무음/loop), leave 시 정지
+
+## Non-Goal
+- 가상 스크롤 도입
+- 백엔드 API 변경
+
+## Review
+- 구현 복잡도: 컴포넌트 내부 상태로 제한
+- 유지보수: 기존 FileThumbnail 단일 책임 유지
+- 성능: 화면 밖 썸네일 fetch 억제
+- 보안: 기존 Bearer 인증/endpoint 재사용
+
+## Tests
+- frontend build
+- 수동: 최초 로딩 skeleton, 스크롤 시 점진 로딩, 영상 hover play 확인


### PR DESCRIPTION
## Summary
썸네일 UX/성능 2차 개선을 적용했습니다.

- 썸네일 로딩 skeleton 추가
- IntersectionObserver 기반 lazy loading
- 동영상 썸네일 hover 미리보기 재생

## Linked Issue
- Closes #113

## Plan
- Ref: `plan/57_thumbnail_ux_performance_round2.md`

## Changes
### FileThumbnail
- 화면 진입 전에는 fetch하지 않도록 lazy 조건 추가
- 로딩 중 Skeleton 표시
- video 썸네일 hover 시 play / leave 시 pause+reset
- 실패 시 기존 아이콘 fallback 유지

## Pn Review
### P1
- 실패 안전성 유지(fallback)
- 기존 인증/endpoint 재사용으로 보안 경계 유지

### P2
- 초기 화면 로드 시 네트워크 부하 감소(lazy)
- 사용자 피드백 개선(skeleton, hover preview)

### P3
- 추후 virtualization과 결합 가능

## Validation
- `frontend npm run build` ✅
