### PR TITLE
perf(backend): cache system health and disable open-in-view

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,6 +8,8 @@ app:
   storage:
     root: /mnt/host_volumes
     cache-dir: ${APP_STORAGE_CACHE_DIR:/tmp/nas-cache}
+  monitoring:
+    health-cache-ttl-ms: ${APP_MONITORING_HEALTH_CACHE_TTL_MS:2000}
   security:
     bootstrap-admin-password: ${APP_SECURITY_BOOTSTRAP_ADMIN_PASSWORD:}
 
@@ -28,6 +30,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     show-sql: false
+    open-in-view: false
     properties:
       hibernate:
         format_sql: false

--- a/plan/58_backend_perf_health_cache_openinview.md
+++ b/plan/58_backend_perf_health_cache_openinview.md
@@ -1,0 +1,29 @@
+# Plan 58 - Backend Performance: Health Cache + Open-in-View Off
+
+## Goal
+백엔드 성능/안정성 관점에서 저위험 고효율 개선 포인트를 반영한다.
+
+## Selected Points
+1. System health endpoint short-TTL cache
+   - 대상: `SystemMonitoringService#getSystemHealth`
+   - 이유: meter/filesystem 조회 반복 비용 완화
+2. JPA Open Session In View 비활성화
+   - 설정: `spring.jpa.open-in-view=false`
+   - 이유: 요청 전 구간 영속성 컨텍스트 유지 비용 제거, 계층 경계 명확화
+
+## Design
+- `app.monitoring.health-cache-ttl-ms` (default 2000ms) 추가
+- 캐시가 유효하면 기존 DTO 재사용
+- 캐시 만료 시 새 값 계산 후 갱신
+- storage root 디렉토리 준비는 생성자에서 1회 수행(요청 시 반복 createDirectories 제거)
+
+## Review
+- 구현 복잡도: 낮음
+- 유지보수: 설정 기반 튜닝 가능
+- 성능: health polling 빈도가 높을수록 효과 증가
+- 사이드이펙트: health 값이 TTL 동안 약간 stale 가능(운영상 허용 범위)
+
+## Tests
+- backend test
+- smoke e2e
+- CI checks


### PR DESCRIPTION
## Summary
Backend 성능 개선 포인트 탐색 후 저위험/고효율 항목 2개를 반영했습니다.

1. System health endpoint short-TTL cache
2. JPA open-in-view 비활성화

## Linked Issue
- Closes #115

## Plan
- Ref: `plan/58_backend_perf_health_cache_openinview.md`

## Changes
### 1) Health cache
- `SystemMonitoringService#getSystemHealth`에 TTL 캐시 추가
- 설정: `app.monitoring.health-cache-ttl-ms` (env: `APP_MONITORING_HEALTH_CACHE_TTL_MS`, default 2000)
- TTL 내 재호출 시 계산값 재사용

### 2) Storage root init optimization
- storage root 생성 확인을 요청마다 반복하지 않고 생성자에서 1회 시도

### 3) Open-in-view off
- `spring.jpa.open-in-view=false` 설정
- 요청 전구간 영속성 컨텍스트 유지 비용 제거

## Pn Review
### P1
- side effect: health 값이 TTL 동안 stale 가능 → short TTL(2s)로 운영상 허용 범위
- 보안/인가 경계 변화 없음

### P2
- health polling 빈도 높은 환경에서 CPU/filesystem 조회 비용 감소
- 요청 lifecycle 자원 사용량 감소(open-in-view off)

### P3
- 필요 시 TTL을 환경변수로 조정 가능

## Validation
- `backend ./gradlew test --no-daemon` ✅
