### PR TITLE
perf(frontend): thumbnail cache + windowing-lite + hover debounce

### DIFF
--- a/frontend/src/entities/file/ui/thumbnailCache.ts
+++ b/frontend/src/entities/file/ui/thumbnailCache.ts
@@ -1,0 +1,29 @@
+const CACHE_TTL_MS = 30_000;
+
+type Entry = {
+  promise: Promise<Blob>;
+  createdAt: number;
+};
+
+const cache = new Map<string, Entry>();
+
+export const getCachedBlob = (key: string, fetcher: () => Promise<Blob>): Promise<Blob> => {
+  const now = Date.now();
+  const hit = cache.get(key);
+
+  if (hit && now - hit.createdAt < CACHE_TTL_MS) {
+    return hit.promise;
+  }
+
+  const promise = fetcher().catch((error) => {
+    cache.delete(key);
+    throw error;
+  });
+
+  cache.set(key, {promise, createdAt: now});
+  return promise;
+};
+
+export const clearThumbnailCache = () => {
+  cache.clear();
+};

--- a/plan/59_thumbnail_cache_windowing_hover_debounce.md
+++ b/plan/59_thumbnail_cache_windowing_hover_debounce.md
@@ -1,0 +1,31 @@
+# Plan 59 - Thumbnail Cache + Large List Windowing + Hover Debounce
+
+## Goal
+썸네일/대용량 목록 성능을 3차로 개선한다.
+
+## Scope
+1. Thumbnail memory cache
+   - 동일 미디어 path 재요청 시 fetch 중복 억제
+2. Large list render windowing-lite
+   - 파일 수가 많을 때 초기 렌더를 제한하고 스크롤로 점진 렌더
+3. Video hover debounce
+   - hover 즉시 재생 대신 짧은 지연 후 재생
+
+## Design
+- `thumbnailCache` 유틸(Map 기반 promise cache + TTL)
+- `FileThumbnail`에서 cache 경유 fetch
+- `FileTable`에서 초기 렌더 개수 제한 + scroll-bottom 배치 확장
+- video hover 120~180ms debounce
+
+## Review
+- 과도 설계 방지: 외부 라이브러리 없이 최소 구조
+- 유지보수: 기존 컴포넌트 내부 책임 유지
+- 성능: 중복 fetch/대량 DOM 렌더 비용 완화
+- 사이드이펙트: 파일 선택/컨텍스트/drag-drop 동작 유지
+
+## Tests
+- frontend build
+- 수동:
+  - 동일 폴더 재진입 시 썸네일 로드 체감 개선
+  - 대량 파일 폴더에서 스크롤 시 점진 로드
+  - video hover 시 지연 재생 확인


### PR DESCRIPTION
## Summary
썸네일/대용량 목록 성능 3차 개선을 반영했습니다.

- 썸네일 메모리 캐시(TTL)
- 대량 파일 목록 windowing-lite(점진 렌더)
- 동영상 hover 미리보기 debounce

## Linked Issue
- Closes #117

## Plan
- Ref: `plan/59_thumbnail_cache_windowing_hover_debounce.md`

## Changes
### 1) Thumbnail cache
- `thumbnailCache.ts` 추가
- endpoint key 기준 Promise cache + TTL(30s)
- 동일 썸네일 중복 fetch 억제

### 2) Hover debounce
- video hover 시 150ms 지연 후 play
- leave 시 timer clear + pause/reset

### 3) Windowing-lite
- `FileTable`에서 초기 렌더 개수 제한(300)
- 스크롤 하단 접근 시 배치 렌더(+200)
- mobile list / grid / table에 적용

## Pn Review
### P1
- 기능 안전성: 기존 fallback/selection/drag-drop 흐름 유지
- side effect: 대량 목록에서 점진 렌더로 초기 DOM 폭증 완화

### P2
- UX: hover 오작동(스치기 재생) 감소
- 성능: 동일 파일 재진입 시 썸네일 fetch 재사용

### P3
- 향후: true virtualization(react-virtual)로 확장 가능

## Validation
- `frontend npm run build` ✅
