### PR TITLE
perf(backend): optimize list path and add preview/audit observability

### DIFF
--- a/backend/src/main/resources/db/migration/V6__add_audit_logs_timestamp_id_index.sql
+++ b/backend/src/main/resources/db/migration/V6__add_audit_logs_timestamp_id_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_audit_logs_timestamp_id_desc
+    ON audit_logs (timestamp DESC, id DESC);

--- a/backend/src/test/java/com/manas/backend/context/file/application/service/PreviewServiceTest.java
+++ b/backend/src/test/java/com/manas/backend/context/file/application/service/PreviewServiceTest.java
@@ -17,6 +17,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.UUID;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,12 +36,18 @@ class PreviewServiceTest {
     private FileStoragePort fileStoragePort;
     @Mock
     private PreviewGeneratorPort previewGeneratorPort;
+    @Mock
+    private MeterRegistry meterRegistry;
+    @Mock
+    private Counter counter;
     private PreviewService previewService;
     private UUID userId;
 
     @BeforeEach
     void setUp() {
-        previewService = new PreviewService(fileStoragePort, previewGeneratorPort, tempCacheDir.toString());
+        when(meterRegistry.counter(any())).thenReturn(counter);
+        previewService = new PreviewService(fileStoragePort, previewGeneratorPort, meterRegistry,
+                tempCacheDir.toString());
         userId = UUID.randomUUID();
     }
 

--- a/plan/60_backend_perf_round2_list_preview_audit.md
+++ b/plan/60_backend_perf_round2_list_preview_audit.md
@@ -1,0 +1,29 @@
+# Plan 60 - Backend Performance Round 2
+
+## Goal
+백엔드 성능 2차 개선: 대용량 디렉토리 목록 처리 비용 완화 + preview 캐시 관측성 + audit 조회 인덱스 보강.
+
+## Scope
+1. Directory listing optimization (name sort 경로)
+   - 전체 항목 메타데이터 읽기 대신, 페이지 구간에만 상세 속성 조회
+2. Preview cache metrics
+   - cache hit/miss 카운터 기록
+3. Audit logs index migration
+   - `(timestamp DESC, id DESC)` 조회 패턴 최적화용 인덱스 추가
+
+## Design
+- `LocalFileSystemAdapter#listDirectory`에서 sort별 분기
+  - NAME_ASC/DESC: path + isDirectory만으로 정렬/페이징, 페이징된 항목만 `readAttributes`
+  - MODIFIED_*: 기존 전체 메타 조회 유지
+- `PreviewService`에 MeterRegistry 주입 후 counter 증가
+- Flyway `V6__add_audit_logs_timestamp_id_index.sql` 추가
+
+## Review
+- 복잡도: 중간 (분기 추가)
+- 유지보수: sort 전략 분리로 가독성 유지
+- 성능: large directory + name sort에서 metadata IO 감소 기대
+- 보안/사이드이펙트: 기존 권한/경로 검증 로직 유지
+
+## Tests
+- backend test
+- smoke e2e (CI)


### PR DESCRIPTION
## Summary
백엔드 성능 2차 라운드를 반영했습니다.

- 대용량 디렉토리 name sort 경로 최적화
- preview cache hit/miss 관측 지표 추가
- audit 로그 조회 패턴 인덱스 migration 추가

## Linked Issue
- Closes #119

## Plan
- Ref: `plan/60_backend_perf_round2_list_preview_audit.md`

## Changes
### 1) Directory listing optimization
- `LocalFileSystemAdapter#listDirectory`
  - `NAME_ASC/NAME_DESC` 경로 분리
  - 전체 항목에 대해 상세 attributes를 읽지 않고,
    `Path + isDirectory`만으로 정렬/페이징 후 페이지 구간에만 상세 attrs 조회
- `MODIFIED_*` 정렬은 기존 동작 유지

### 2) Preview cache metrics
- `PreviewService`에 MeterRegistry 기반 counter 추가
  - `app.preview.cache.hit`
  - `app.preview.cache.miss`

### 3) Audit index migration
- `V6__add_audit_logs_timestamp_id_index.sql`
  - `(timestamp DESC, id DESC)` 인덱스 추가

### 4) Tests
- `PreviewServiceTest` constructor 변경(MeterRegistry 주입) 반영

## Pn Review
### P1
- 보안/권한 경계 변화 없음
- 정렬 semantics 유지(디렉토리 우선 + 이름 정렬)

### P2
- large directory + name sort 시 메타데이터 I/O 감소 기대
- preview 캐시 hit ratio 운영 관측 가능

### P3
- 이후 modified sort도 스트리밍/partial 전략으로 추가 최적화 가능

## Validation
- `backend ./gradlew test --no-daemon` ✅
