### PR TITLE
perf(frontend): virtualized table + thumbnail cache stats + benchmark guide

### DIFF
--- a/docs/perf/large_folder_benchmark.md
+++ b/docs/perf/large_folder_benchmark.md
@@ -1,0 +1,33 @@
+# Large Folder Benchmark Guide
+
+## Purpose
+파일 브라우저 대용량 폴더 렌더링 성능을 반복 측정하기 위한 가이드.
+
+## Environment
+- Frontend: production build + nginx container
+- Browser: Chrome (Incognito 권장)
+- Dataset: 1,000 / 5,000 / 10,000 files 단계별 폴더
+
+## Steps
+1. 테스트 데이터 준비
+2. `frontend npm run build` 후 앱 기동
+3. Chrome DevTools > Performance 열기
+4. 파일 브라우저 진입 후 대상 폴더 열기
+5. 다음 시나리오 각각 3회 측정
+   - 최초 진입 렌더
+   - 스크롤 하단 이동
+   - 같은 폴더 재진입(썸네일 캐시 효과)
+
+## Metrics to Record
+- Time to first rows visible
+- Main thread long task count (>50ms)
+- Memory peak (JS heap)
+- Thumbnail request count (Network)
+
+## Pass Criteria (example)
+- 5,000 files: initial render no freeze (>2s UI freeze 없음)
+- same-folder revisit: thumbnail fetch count significantly reduced
+
+## Notes
+- 브라우저 확장/백그라운드 탭 최소화
+- 테스트 중 네트워크 변동이 크면 재측정

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^7.3.7",
         "@mui/material": "^7.3.7",
         "@tanstack/react-query": "^5.90.16",
+        "@tanstack/react-virtual": "^3.13.12",
         "axios": "^1.13.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1696,6 +1697,33 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.18.tgz",
+      "integrity": "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz",
+      "integrity": "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.7",
     "@tanstack/react-query": "^5.90.16",
+    "@tanstack/react-virtual": "^3.13.12",
     "axios": "^1.13.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/entities/file/ui/thumbnailCache.ts
+++ b/frontend/src/entities/file/ui/thumbnailCache.ts
@@ -6,14 +6,19 @@ type Entry = {
 };
 
 const cache = new Map<string, Entry>();
+let cacheHit = 0;
+let cacheMiss = 0;
 
 export const getCachedBlob = (key: string, fetcher: () => Promise<Blob>): Promise<Blob> => {
   const now = Date.now();
   const hit = cache.get(key);
 
   if (hit && now - hit.createdAt < CACHE_TTL_MS) {
+    cacheHit += 1;
     return hit.promise;
   }
+
+  cacheMiss += 1;
 
   const promise = fetcher().catch((error) => {
     cache.delete(key);
@@ -26,4 +31,13 @@ export const getCachedBlob = (key: string, fetcher: () => Promise<Blob>): Promis
 
 export const clearThumbnailCache = () => {
   cache.clear();
+  cacheHit = 0;
+  cacheMiss = 0;
 };
+
+export const getThumbnailCacheStats = () => ({
+  size: cache.size,
+  hit: cacheHit,
+  miss: cacheMiss,
+  hitRatio: cacheHit + cacheMiss === 0 ? 0 : cacheHit / (cacheHit + cacheMiss),
+});

--- a/plan/61_frontend_virtualization_cache_metrics_benchmark.md
+++ b/plan/61_frontend_virtualization_cache_metrics_benchmark.md
@@ -1,0 +1,32 @@
+# Plan 61 - True Virtualization + Thumbnail Cache Metrics + Large Folder Benchmark
+
+## Goal
+파일 브라우저 대용량 성능 개선 4차 라운드.
+
+## Scope
+1. true virtualization 도입 (`@tanstack/react-virtual`)
+   - 최소 1개 핵심 뷰(Desktop list/table)에 적용
+2. thumbnail cache hit/miss 계측
+   - frontend 메모리 캐시의 hit/miss 카운터 노출
+3. 대용량 폴더 benchmark 시나리오 문서화
+   - 반복 측정 가능한 실행 절차 제공
+
+## Non-Goal
+- backend API 변경
+- 전 뷰(모바일/그리드/테이블) 동시 완전 전환
+
+## Design
+- `@tanstack/react-virtual` 추가
+- `FileTable` desktop list에서 virtual row 렌더
+- `thumbnailCache`에 hit/miss 카운터 + accessor 함수
+- `docs/perf/large_folder_benchmark.md` 추가
+
+## Review
+- 과도성 점검: 우선 hotspot 뷰만 virtualization 적용
+- 유지보수: 기존 DnD/selection 흐름 보존
+- 성능: DOM row 수를 뷰포트 근처로 제한
+- 사이드이펙트: 목록 선택/드래그 동작 회귀 점검
+
+## Tests
+- `frontend npm ci && npm run build`
+- 수동: 대용량 폴더에서 스크롤 성능 및 DnD/선택 동작 확인


### PR DESCRIPTION
## Summary
프론트 성능 4차 라운드 반영:

1. desktop list/table true virtualization (`@tanstack/react-virtual`)
2. thumbnail cache hit/miss 계측 노출
3. 대용량 폴더 benchmark 가이드 문서 추가

## Linked Issue
- Closes #121

## Plan
- Ref: `plan/61_frontend_virtualization_cache_metrics_benchmark.md`

## Changes
### 1) True virtualization
- `FileTable` desktop list/table 경로에 `useVirtualizer` 적용
- 렌더링 row 수를 뷰포트 + overscan 범위로 제한
- 기존 DnD/선택/컨텍스트 동작은 row 렌더 로직에 그대로 유지

### 2) Thumbnail cache metrics
- `thumbnailCache.ts`
  - hit/miss 카운터 추가
  - `getThumbnailCacheStats()` 제공
  - clear 시 카운터 reset

### 3) Benchmark scenario
- `docs/perf/large_folder_benchmark.md` 추가
- 반복 가능한 측정 절차/지표 정의

## Pn Review
### P1
- 기능 안전성: 기존 파일 액션 경로 유지
- 성능 이득: 대량 row DOM 생성 억제로 scroll 성능 개선

### P2
- 계측성: cache hit ratio 확인 가능
- 유지보수: hotspot 뷰 우선 적용(과도한 전면 전환 회피)

### P3
- 향후 mobile/grid virtualization 확장 여지

## Validation
- `frontend npm install`
- `frontend npm run build` ✅
