### PR TITLE
perf(backend): optimize modified sort and expose preview/audit p95 metrics

### DIFF
--- a/backend/src/main/java/com/manas/backend/context/system/infrastructure/web/dto/SystemHealthDto.java
+++ b/backend/src/main/java/com/manas/backend/context/system/infrastructure/web/dto/SystemHealthDto.java
@@ -1,11 +1,15 @@
 package com.manas.backend.context.system.infrastructure.web.dto;
 
 public record SystemHealthDto(
-        double cpuUsage,      // 0.0 to 1.0 (percentage)
-        long memoryUsed,      // Bytes
-        long memoryTotal,     // Bytes
-        long storageUsed,     // Bytes
-        long storageTotal     // Bytes
+        double cpuUsage,
+        long memoryUsed,
+        long memoryTotal,
+        long storageUsed,
+        long storageTotal,
+        double previewCacheHit,
+        double previewCacheMiss,
+        double previewCacheHitRatio,
+        double auditLogsQueryP95Ms
 ) {
 
 }

--- a/backend/src/test/java/com/manas/backend/context/system/application/service/AuditLogServiceTest.java
+++ b/backend/src/test/java/com/manas/backend/context/system/application/service/AuditLogServiceTest.java
@@ -9,6 +9,7 @@ import com.manas.backend.common.tracing.TraceConstants;
 import com.manas.backend.context.system.application.port.out.LoadAuditLogsPort;
 import com.manas.backend.context.system.application.port.out.SaveAuditLogPort;
 import com.manas.backend.context.system.domain.AuditLog;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -33,14 +34,14 @@ class AuditLogServiceTest {
 
     private LoadAuditLogsPort loadAuditLogsPort;
 
-
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     private AuditLogService auditLogService;
 
     @BeforeEach
     void setUp() {
 
-        auditLogService = new AuditLogService(saveAuditLogPort, loadAuditLogsPort);
+        auditLogService = new AuditLogService(saveAuditLogPort, loadAuditLogsPort, meterRegistry);
 
     }
 

--- a/backend/src/test/java/com/manas/backend/context/system/infrastructure/web/SystemMonitoringControllerTest.java
+++ b/backend/src/test/java/com/manas/backend/context/system/infrastructure/web/SystemMonitoringControllerTest.java
@@ -53,17 +53,15 @@ class SystemMonitoringControllerTest {
         // Given
 
         SystemHealthDto mockHealth = new SystemHealthDto(
-
                 0.45,
-
                 512000000L,
-
                 1024000000L,
-
                 10000000000L,
-
-                50000000000L
-
+                50000000000L,
+                10,
+                2,
+                0.8333,
+                12.5
         );
 
         when(getSystemHealthUseCase.getSystemHealth()).thenReturn(mockHealth);

--- a/plan/62_backend_perf_round3_modifiedsort_metrics.md
+++ b/plan/62_backend_perf_round3_modifiedsort_metrics.md
@@ -1,0 +1,27 @@
+# Plan 62 - Backend Performance Round 3
+
+## Goal
+다음 백엔드 성능 라운드 진행:
+1) modified sort 경로 최적화 확장
+2) preview cache hit ratio 대시보드 노출
+3) audit 로그 API p95 계측
+
+## Scope
+- LocalFileSystemAdapter: MODIFIED_* 정렬용 lightweight entry 도입
+- AuditLogService: query timer 계측 추가
+- SystemMonitoringService/DTO: preview cache hit/miss/hitRatio + audit query p95(ms) 노출
+
+## Design
+- 파일 목록 정렬 시 name/modified 각각 전략 분리
+- preview counters(`app.preview.cache.hit/miss`)를 system health 응답에 포함
+- `app.audit.logs.query` timer p95 값을 system health 응답에 포함
+
+## Review
+- 과도성 방지: 기존 API shape 유지 + health 필드 확장만 수행
+- 유지보수: sort 전략 메서드 분리
+- 성능: large directory에서 modified sort 불필요 metadata 로드 완화
+- 보안/사이드이펙트: 권한/경로 검증 로직 불변
+
+## Tests
+- backend test
+- CI checks


### PR DESCRIPTION
## Summary
백엔드 성능 3차 라운드를 반영했습니다.

1. modified sort 경로 목록 최적화 확장
2. preview cache hit/miss/hitRatio system health 노출
3. audit logs query p95(ms) system health 노출

## Linked Issue
- Closes #123

## Plan
- Ref: `plan/62_backend_perf_round3_modifiedsort_metrics.md`

## Changes
### Directory listing (modified sort)
- `LocalFileSystemAdapter`
  - `NAME_*` / `MODIFIED_*` 각각 전략 분리
  - `MODIFIED_*`는 경량 entry(path, isDirectory, lastModified) 정렬 후 페이지 구간만 상세 attrs 조회

### Metrics exposure
- `AuditLogService`
  - `app.audit.logs.query` timer + p95 percentile publish
- `SystemMonitoringService`
  - `app.preview.cache.hit/miss` 조회
  - hitRatio 계산
  - audit query p95(ms) 조회
- `SystemHealthDto` 확장
  - previewCacheHit, previewCacheMiss, previewCacheHitRatio, auditLogsQueryP95Ms

### Tests
- `AuditLogServiceTest` 생성자/registry 반영
- `SystemMonitoringControllerTest` DTO 필드 확장 반영

## Pn Review
### P1
- 권한/보안 경계 변경 없음
- 기존 API 계약(health endpoint) 확장만 수행

### P2
- modified sort large directory에서 불필요 metadata 조회 부담 완화
- 운영에서 preview/audit 성능 지표 확인 가능

### P3
- 향후 p95 외 p99/throughput 대시보드 연계 가능

## Validation
- `backend ./gradlew test --no-daemon` ✅
