### PR TITLE
feat(frontend): expose preview/audit perf metrics in system health

### DIFF
--- a/frontend/src/entities/system/model/types.ts
+++ b/frontend/src/entities/system/model/types.ts
@@ -4,4 +4,8 @@ export interface SystemHealth {
   memoryTotal: number;
   storageUsed: number;
   storageTotal: number;
+  previewCacheHit: number;
+  previewCacheMiss: number;
+  previewCacheHitRatio: number;
+  auditLogsQueryP95Ms: number;
 }

--- a/frontend/src/widgets/system-health/ui/SystemHealthWidget.tsx
+++ b/frontend/src/widgets/system-health/ui/SystemHealthWidget.tsx
@@ -3,6 +3,8 @@ import {Box, CircularProgress, Stack, Typography} from '@mui/material';
 import MemoryIcon from '@mui/icons-material/Memory';
 import StorageIcon from '@mui/icons-material/Storage';
 import SpeedIcon from '@mui/icons-material/Speed';
+import InsightsIcon from '@mui/icons-material/Insights';
+import QueryStatsIcon from '@mui/icons-material/QueryStats';
 import {AppCard} from '@/shared/ui';
 import type {SystemHealth} from '@/entities/system/model/types';
 
@@ -62,9 +64,10 @@ export const SystemHealthWidget: React.FC<SystemHealthWidgetProps> = ({data, isL
 
   const memoryPercent = ((data.memoryUsed / data.memoryTotal) * 100).toFixed(1);
   const storagePercent = ((data.storageUsed / data.storageTotal) * 100).toFixed(1);
+  const previewHitRatioPercent = (data.previewCacheHitRatio * 100).toFixed(1);
 
   return (
-      <Stack direction={{xs: 'column', md: 'row'}} spacing={3}>
+      <Stack direction={{xs: 'column', md: 'row'}} spacing={3} flexWrap="wrap" useFlexGap>
         <Box flex={1}>
           <StatCard
               title="CPU Usage"
@@ -80,12 +83,30 @@ export const SystemHealthWidget: React.FC<SystemHealthWidgetProps> = ({data, isL
               icon={<MemoryIcon color="secondary"/>}
           />
         </Box>
-        <Box flex={1}>
+        <Box flex={1} minWidth={{md: 260}}>
           <StatCard
               title="Storage"
               value={formatBytes(data.storageUsed)}
               subValue={`${storagePercent}% of ${formatBytes(data.storageTotal)}`}
               icon={<StorageIcon color="success"/>}
+          />
+        </Box>
+
+        <Box flex={1} minWidth={{md: 260}}>
+          <StatCard
+              title="Preview Cache"
+              value={`${previewHitRatioPercent}% hit`}
+              subValue={`hit ${data.previewCacheHit.toFixed(0)} / miss ${data.previewCacheMiss.toFixed(0)}`}
+              icon={<InsightsIcon color="info"/>}
+          />
+        </Box>
+
+        <Box flex={1} minWidth={{md: 260}}>
+          <StatCard
+              title="Audit Query P95"
+              value={data.auditLogsQueryP95Ms >= 0 ? `${data.auditLogsQueryP95Ms.toFixed(1)} ms` : 'N/A'}
+              subValue="/api/admin/system/audit-logs latency"
+              icon={<QueryStatsIcon color="warning"/>}
           />
         </Box>
       </Stack>

--- a/plan/63_system_health_perf_metrics_ui.md
+++ b/plan/63_system_health_perf_metrics_ui.md
@@ -1,0 +1,24 @@
+# Plan 63 - System Health UI: Performance Metrics Exposure
+
+## Goal
+백엔드에서 추가한 성능 지표(preview cache/audit p95)를 Admin System Health 화면에 표시한다.
+
+## Scope
+1. `SystemHealth` frontend 타입 확장
+2. `SystemHealthWidget`에 성능 지표 카드 2개 추가
+   - Preview Cache Hit Ratio
+   - Audit Logs Query P95
+
+## Non-Goal
+- 백엔드 API 변경
+- 새로운 차트 라이브러리 도입
+
+## Review
+- 과도성 방지: 기존 카드 UI 재사용
+- 유지보수: 타입/표시 로직만 최소 변경
+- 가독성: 퍼센트/건수/ms 단위 명확히 표기
+- 사이드이펙트: 기존 System Health 카드 동작 불변
+
+## Tests
+- frontend build
+- 수동 확인: Admin > System Health에서 신규 지표 카드 노출


### PR DESCRIPTION
## Summary
System Health 화면에 backend 성능 지표를 노출했습니다.

- Preview cache hit/miss/hitRatio
- Audit logs query p95(ms)

## Linked Issue
- Closes #125

## Plan
- Ref: `plan/63_system_health_perf_metrics_ui.md`

## Changes
- `SystemHealth` 타입 확장
  - `previewCacheHit`, `previewCacheMiss`, `previewCacheHitRatio`, `auditLogsQueryP95Ms`
- `SystemHealthWidget` 카드 추가
  - Preview Cache
  - Audit Query P95
- 카드 레이아웃을 wrap 가능한 형태로 조정

## Pn Review
### P1
- backend API 계약 확장 필드 정확히 반영
- 값 부재/음수 케이스에서 `N/A` 처리

### P2
- 단위 가독성 강화(%/count/ms)
- 기존 CPU/Memory/Storage 표시 회귀 없음

### P3
- 추후 미니 차트/추이 그래프로 확장 가능

## Validation
- `frontend npm run build` ✅
