### PR TITLE
feat(frontend): add mini trend sparkline in system health

### DIFF
--- a/plan/64_system_health_trend_mini.md
+++ b/plan/64_system_health_trend_mini.md
@@ -1,0 +1,22 @@
+# Plan 64 - System Health Mini Trend
+
+## Goal
+Admin System Health 지표에 최근 추이를 표시해 운영 관측성을 높인다.
+
+## Scope
+1. Preview Cache Hit Ratio 추이
+2. Audit Query P95(ms) 추이
+3. 최근 N개 샘플 기반 mini trend(텍스트 sparkline)
+
+## Non-Goal
+- 백엔드 API 변경
+- 외부 차트 라이브러리 도입
+
+## Design
+- `useSystemHealth` 5초 polling 데이터를 위젯 내부 history로 유지(최근 24개)
+- 간단 sparkline(유니코드 블록) 렌더 함수 구현
+- 현재값 + 최근 추이 + 범위(min/max) 표시
+
+## Tests
+- frontend build
+- 수동: 1~2분 관찰 시 trend가 누적/갱신되는지 확인


### PR DESCRIPTION
## Summary
System Health 성능 지표 카드에 mini trend를 추가했습니다.

- Preview Cache Hit Ratio trend
- Audit Query P95 trend

## Linked Issue
- Closes #127

## Plan
- Ref: `plan/64_system_health_trend_mini.md`

## Changes
- `SystemHealthWidget`
  - 최근 24개 샘플 history 상태 유지
  - 유니코드 sparkline 렌더 함수 추가
  - Preview/Audit 카드 subtext에 trend 표시

## Pn Review
### P1
- 기존 API/권한 경계 변경 없음
- 데이터 없을 때 안전 fallback(`-`) 처리

### P2
- polling 데이터의 추세를 즉시 파악 가능
- 외부 차트 라이브러리 미도입으로 유지보수 부담 최소화

### P3
- 향후 선형차트/시간축 라벨 확장 가능

## Validation
- `frontend npm run build` ✅
