### PR TITLE
feat(uiux): complete context menu actions (issue #133)

### DIFF
--- a/plan/69_issue133_context_menu_actions.md
+++ b/plan/69_issue133_context_menu_actions.md
@@ -1,0 +1,19 @@
+# Issue #133 Plan — Complete Context Menu Actions
+
+## Scope (minimal complete)
+- Extend file context menu with: Open, Move, Copy, Rename, Delete, Share.
+- Implement practical actions using existing capabilities.
+- Add disabled states based on item type / selection state.
+
+## Implementation
+1. Add Move modal invocation from context menu.
+2. Add Rename dialog and implement rename via move API (same folder, new name).
+3. Add Delete action for focused item.
+4. Add Copy (name) and Share (path) clipboard actions.
+5. Keep Open only for directories; disable non-applicable actions.
+
+## Validation
+- `cd frontend && npm run build`
+
+## Notes
+- Backend has no dedicated copy/share endpoint, so this scope uses clipboard-based UX for Copy/Share.


### PR DESCRIPTION
Closes #133\n\n## What changed\n- Expanded file context menu to Open / Move / Copy / Rename / Delete / Share\n- Wired Move to existing move modal flow\n- Added rename dialog (implemented via move API within current directory)\n- Added delete action for focused item\n- Added clipboard-based Copy(name) and Share(path) actions\n- Added disabled states for unsupported state combinations\n\n## Validation\n- 
> frontend@0.0.0 build
> tsc -b && vite build

rolldown-vite v7.2.5 building client environment for production...
[2Ktransforming...✓ 1093 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                               0.73 kB │ gzip:   0.37 kB
dist/assets/index-DwS8hgf5.css                0.34 kB │ gzip:   0.25 kB
dist/assets/queryKeys-CNP9m3Yg.js             0.14 kB │ gzip:   0.13 kB
dist/assets/rolldown-runtime-DGruFWvd.js      0.63 kB │ gzip:   0.38 kB
dist/assets/UserTable-XpfPmGe4.js             1.30 kB │ gzip:   0.65 kB
dist/assets/AuditLogTable-CkjHlvH-.js         1.54 kB │ gzip:   0.71 kB
dist/assets/ChangePasswordPage-C5xbp9QT.js    2.13 kB │ gzip:   0.97 kB
dist/assets/LoginPage-cV-D_xcl.js             2.21 kB │ gzip:   1.11 kB
dist/assets/ui-Cmy4jHLn.js                    2.85 kB │ gzip:   1.23 kB
dist/assets/SystemHealthWidget-BU8yrFqM.js    2.99 kB │ gzip:   1.32 kB
dist/assets/AdminPage-BKjiuEQ8.js             4.37 kB │ gzip:   1.84 kB
dist/assets/index-AZvDyiL5.js                10.76 kB │ gzip:   4.31 kB
dist/assets/DashboardPage-DYHa3Fhw.js        27.98 kB │ gzip:   8.99 kB
dist/assets/vendor-fVfFS3mQ.js              130.08 kB │ gzip:  44.16 kB
dist/assets/react-Bf0jwt9H.js               178.30 kB │ gzip:  56.32 kB
dist/assets/mui-DjqrXgMB.js                 355.93 kB │ gzip: 107.26 kB
✓ built in 121ms\n\n## Pn self-review\n- Kept scope focused to context-menu UX only\n- Reused existing move/delete APIs and modal patterns\n- Used clipboard fallback for copy/share due to absent backend endpoints