### PR TITLE
feat(uiux): left navigation with favorites/recent paths (issue #135)

### DIFF
--- a/plan/71_issue135_left_navigation_favorites_recent.md
+++ b/plan/71_issue135_left_navigation_favorites_recent.md
@@ -1,0 +1,9 @@
+# Issue #135 Plan — Left Navigation Tree with Favorites/Recent Paths
+
+## Scope
+- Add left-side navigation area for favorites and recent paths.
+- Persist favorites/recent in localStorage.
+- Keep UX simple and aligned with existing file browser layout.
+
+## Validation
+- `cd frontend && npm run build`


### PR DESCRIPTION
Closes #135\n\n## What changed\n- Added file-browser side navigation panel for Favorites and Recent paths\n- Added localStorage persistence for favorites/recent path history\n- Added one-click toggle for current path favorite\n\n## Validation\n- 
> frontend@0.0.0 build
> tsc -b && vite build

rolldown-vite v7.2.5 building client environment for production...
[2Ktransforming...✓ 1093 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                               0.73 kB │ gzip:   0.36 kB
dist/assets/index-DwS8hgf5.css                0.34 kB │ gzip:   0.25 kB
dist/assets/queryKeys-CNP9m3Yg.js             0.14 kB │ gzip:   0.13 kB
dist/assets/rolldown-runtime-DGruFWvd.js      0.63 kB │ gzip:   0.38 kB
dist/assets/UserTable-XpfPmGe4.js             1.30 kB │ gzip:   0.65 kB
dist/assets/AuditLogTable-CkjHlvH-.js         1.54 kB │ gzip:   0.71 kB
dist/assets/ChangePasswordPage-YxSyS1d-.js    2.13 kB │ gzip:   0.97 kB
dist/assets/LoginPage-Btc3y0bJ.js             2.21 kB │ gzip:   1.11 kB
dist/assets/ui-Cmy4jHLn.js                    2.85 kB │ gzip:   1.23 kB
dist/assets/SystemHealthWidget-BU8yrFqM.js    2.99 kB │ gzip:   1.32 kB
dist/assets/AdminPage-CzWPMjjR.js             4.37 kB │ gzip:   1.84 kB
dist/assets/index-CVi2a9q3.js                10.76 kB │ gzip:   4.31 kB
dist/assets/DashboardPage-BG2MgIMP.js        30.18 kB │ gzip:   9.48 kB
dist/assets/vendor-fVfFS3mQ.js              130.08 kB │ gzip:  44.16 kB
dist/assets/react-Bf0jwt9H.js               178.30 kB │ gzip:  56.32 kB
dist/assets/mui-DjqrXgMB.js                 355.93 kB │ gzip: 107.26 kB
✓ built in 125ms\n\n## Pn self-review\n- Kept implementation lightweight and local-state based\n- No backend/API changes