### PR TITLE
feat(uiux): smart path bar (issue #136)

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -72,6 +72,7 @@ export const FileBrowser: React.FC = () => {
   } = useFileBrowser();
 
   const [searchQuery, setSearchQuery] = React.useState('');
+  const [pathInput, setPathInput] = React.useState(currentPath);
   const [sortMode, setSortMode] = React.useState<SortMode>('name-asc');
   const [focusedFile, setFocusedFile] = React.useState<FileNode | null>(null);
   const [contextAnchor, setContextAnchor] = React.useState<null | HTMLElement>(null);
@@ -142,6 +143,10 @@ export const FileBrowser: React.FC = () => {
       setSelectionAnchorIndex(null);
     }
   }, [selectedFiles]);
+
+  React.useEffect(() => {
+    setPathInput(currentPath);
+  }, [currentPath]);
 
   React.useEffect(() => {
     localStorage.setItem('fileBrowser.favorites', JSON.stringify(favorites));
@@ -303,6 +308,29 @@ export const FileBrowser: React.FC = () => {
 
         {data && (
             <Box mb={2}>
+              <Stack direction={{xs: 'column', md: 'row'}} spacing={1} sx={{mb: 1}}>
+                <TextField
+                  size="small"
+                  label="Path"
+                  value={pathInput}
+                  onChange={(e) => setPathInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && pathInput.trim()) navigateToPath(pathInput.trim());
+                  }}
+                  sx={{flex: 1}}
+                />
+                <FormControl size="small" sx={{minWidth: {xs: '100%', md: 220}}}>
+                  <InputLabel id="recent-path-label">Recent</InputLabel>
+                  <Select
+                    labelId="recent-path-label"
+                    label="Recent"
+                    value=""
+                    onChange={(e) => navigateToPath(e.target.value)}
+                  >
+                    {recentPaths.map((p) => <MenuItem key={p} value={p}>{p}</MenuItem>)}
+                  </Select>
+                </FormControl>
+              </Stack>
               <AppBreadcrumbs breadcrumbs={data.breadcrumbs} onNavigate={navigateTo}/>
             </Box>
         )}

--- a/plan/72_issue136_smart_path_bar.md
+++ b/plan/72_issue136_smart_path_bar.md
@@ -1,0 +1,9 @@
+# Issue #136 Plan — Smart Path Bar
+
+## Scope
+- Add direct path input navigation.
+- Keep breadcrumb navigation.
+- Add recent-path quick dropdown.
+
+## Validation
+- `cd frontend && npm run build`


### PR DESCRIPTION
Closes #136\n\n## What changed\n- Added direct path input with Enter navigation\n- Preserved breadcrumb navigation\n- Added recent path dropdown for quick jumps\n\n## Validation\n- 
> frontend@0.0.0 build
> tsc -b && vite build

rolldown-vite v7.2.5 building client environment for production...
[2Ktransforming...✓ 1093 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                               0.73 kB │ gzip:   0.36 kB
dist/assets/index-DwS8hgf5.css                0.34 kB │ gzip:   0.25 kB
dist/assets/queryKeys-CNP9m3Yg.js             0.14 kB │ gzip:   0.13 kB
dist/assets/rolldown-runtime-DGruFWvd.js      0.63 kB │ gzip:   0.38 kB
dist/assets/UserTable-XpfPmGe4.js             1.30 kB │ gzip:   0.65 kB
dist/assets/AuditLogTable-CkjHlvH-.js         1.54 kB │ gzip:   0.71 kB
dist/assets/ChangePasswordPage-BYcxXvXq.js    2.13 kB │ gzip:   0.97 kB
dist/assets/LoginPage-BiVPiuAN.js             2.21 kB │ gzip:   1.11 kB
dist/assets/ui-Cmy4jHLn.js                    2.85 kB │ gzip:   1.23 kB
dist/assets/SystemHealthWidget-BU8yrFqM.js    2.99 kB │ gzip:   1.32 kB
dist/assets/AdminPage-BkIxIsQ4.js             4.37 kB │ gzip:   1.84 kB
dist/assets/index-Sh21pjlb.js                10.76 kB │ gzip:   4.31 kB
dist/assets/DashboardPage-CC0YS6E6.js        30.76 kB │ gzip:   9.59 kB
dist/assets/vendor-fVfFS3mQ.js              130.08 kB │ gzip:  44.16 kB
dist/assets/react-Bf0jwt9H.js               178.30 kB │ gzip:  56.32 kB
dist/assets/mui-DjqrXgMB.js                 355.93 kB │ gzip: 107.26 kB
✓ built in 121ms\n\n## Pn self-review\n- Focused only on path-bar UX enhancements\n- Reused existing navigation state