### PR TITLE
feat(uiux): sort/filter presets (issue #138)

### DIFF
--- a/plan/74_issue138_sort_filter_presets.md
+++ b/plan/74_issue138_sort_filter_presets.md
@@ -1,0 +1,8 @@
+# Issue #138 Plan — Sort/Filter Presets
+
+## Scope
+- Add common file-workflow presets: recent, large, media, documents.
+- Keep preset state in current session UI.
+
+## Validation
+- `cd frontend && npm run build`


### PR DESCRIPTION
Closes #138\n\n## What changed\n- Added preset filter dropdown: All / Recent / Large / Media / Documents\n- Integrated preset filtering with existing search + sort pipeline\n\n## Validation\n- 
> frontend@0.0.0 build
> tsc -b && vite build

rolldown-vite v7.2.5 building client environment for production...
[2Ktransforming...✓ 1093 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                               0.73 kB │ gzip:   0.36 kB
dist/assets/index-DwS8hgf5.css                0.34 kB │ gzip:   0.25 kB
dist/assets/queryKeys-CNP9m3Yg.js             0.14 kB │ gzip:   0.13 kB
dist/assets/rolldown-runtime-DGruFWvd.js      0.63 kB │ gzip:   0.38 kB
dist/assets/UserTable-XpfPmGe4.js             1.30 kB │ gzip:   0.65 kB
dist/assets/AuditLogTable-CkjHlvH-.js         1.54 kB │ gzip:   0.71 kB
dist/assets/ChangePasswordPage-p0Kf58Pb.js    2.13 kB │ gzip:   0.97 kB
dist/assets/LoginPage-CHNHy66O.js             2.21 kB │ gzip:   1.11 kB
dist/assets/ui-Cmy4jHLn.js                    2.85 kB │ gzip:   1.23 kB
dist/assets/SystemHealthWidget-BU8yrFqM.js    2.99 kB │ gzip:   1.32 kB
dist/assets/AdminPage-BDufzNYu.js             4.37 kB │ gzip:   1.84 kB
dist/assets/index-DeaorGQN.js                10.76 kB │ gzip:   4.31 kB
dist/assets/DashboardPage-CKtX-cVV.js        32.01 kB │ gzip:   9.95 kB
dist/assets/vendor-fVfFS3mQ.js              130.08 kB │ gzip:  44.16 kB
dist/assets/react-Bf0jwt9H.js               178.30 kB │ gzip:  56.32 kB
dist/assets/mui-DjqrXgMB.js                 355.93 kB │ gzip: 107.26 kB
✓ built in 123ms\n\n## Pn self-review\n- Minimal frontend-only change\n- Existing patterns preserved