### PR TITLE
feat(uiux): polish sort/filter presets with quick chips

### DIFF
--- a/plan/68_issue138_sort_filter_presets.md
+++ b/plan/68_issue138_sort_filter_presets.md
@@ -1,0 +1,17 @@
+# Plan 68 - Issue #138 Sort/Filter Presets
+
+## Goal
+정렬/필터 프리셋의 반복 사용성을 높인다.
+
+## Scope
+- sort/filter 상태 localStorage 유지
+- 프리셋 quick chips(Recent/Large/Media/Documents)
+- 현재 적용 프리셋 강조 표시
+
+## Non-Goal
+- backend API 변경
+- 고급 쿼리 DSL 추가
+
+## Tests
+- frontend build
+- 수동: 페이지 새로고침 후 sort/filter 유지 확인


### PR DESCRIPTION
## Summary
Issue #138 범위에서 정렬/필터 프리셋 UX를 보강했습니다.

- sort/filter 설정 localStorage 유지
- 프리셋 quick chips(Recent/Large/Media/Documents)
- 활성 프리셋 강조 + 원클릭 clear

## Linked Issue
- Closes #138

## Plan
- `plan/68_issue138_sort_filter_presets.md`

## Validation
- `frontend npm run build` ✅

## Pn Review
### P1
- 반복 탐색에서 프리셋 접근성 강화
### P2
- 페이지 재진입 시 사용자 설정 유지
### P3
- 고급 다중조건 필터는 차후 라운드로 분리
