### PR TITLE
feat(uiux): add trash/recycle flow with restore actions

### DIFF
--- a/plan/69_issue140_trash_recycle_flow.md
+++ b/plan/69_issue140_trash_recycle_flow.md
@@ -1,0 +1,18 @@
+# Plan 69 - Issue #140 Trash/Recycle Bin Flow
+
+## Goal
+영구삭제 대신 휴지통 이동/복원 흐름을 도입한다.
+
+## Scope
+- `/.trash` 경로를 recycle bin으로 사용
+- 일반 경로 삭제 액션: 휴지통 이동
+- 휴지통 경로에서 Restore 액션: 루트(`/`)로 복원
+- 휴지통 보기 버튼 + 상태 안내 추가
+
+## Non-Goal
+- 서버 측 native trash API 추가
+- 원래 경로 복원(메타 저장) 구현
+
+## Tests
+- frontend build
+- 수동: 일반 경로 삭제 시 `/.trash`로 이동, 휴지통에서 restore 동작 확인


### PR DESCRIPTION
## Summary
Issue #140 범위로 휴지통(Trash) 플로우를 추가했습니다.

- 일반 경로 삭제: `/.trash`로 이동
- 휴지통 경로: Restore / Delete Permanently
- Open Trash 진입 버튼 + 휴지통 전용 empty state

## Linked Issue
- Closes #140

## Plan
- `plan/69_issue140_trash_recycle_flow.md`

## Notes
- 서버 native trash API 대신, 현재 move API 기반 soft-delete 형태로 구현
- 복원 대상은 루트(`/`)로 단순화

## Validation
- `frontend npm run build` ✅
