### PR TITLE
feat(uiux): tab UX polish (issue #160)

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -287,9 +287,21 @@ export const FileBrowser: React.FC = () => {
 
   const navigateToPath = (path: string) => navigateTo(path);
 
+  const formatTabPath = (path: string) => {
+    if (path.length <= 26) return path;
+    return `…${path.slice(-25)}`;
+  };
+
   const openNewTab = () => {
-    const nextId = `tab-${Date.now()}`;
     const nextPath = currentPath;
+    const existing = tabs.find((tab) => tab.path === nextPath);
+    if (existing) {
+      setActiveTabId(existing.id);
+      navigateToPath(existing.path);
+      return;
+    }
+
+    const nextId = `tab-${Date.now()}`;
     setTabs((prev) => [...prev, { id: nextId, path: nextPath }]);
     setActiveTabId(nextId);
   };
@@ -520,16 +532,30 @@ export const FileBrowser: React.FC = () => {
 
       <Paper variant="outlined" sx={{ mb: 2, p: 1 }}>
         <Stack direction="row" spacing={1} alignItems="center" sx={{ overflowX: 'auto' }}>
-          {tabs.map((tab, i) => (
-            <Chip
-              key={tab.id}
-              label={`Tab ${i + 1}: ${tab.path}`}
-              color={tab.id === activeTabId ? 'primary' : 'default'}
-              onClick={() => switchTab(tab.id)}
-              onDelete={tabs.length > 1 ? () => closeTab(tab.id) : undefined}
-              variant={tab.id === activeTabId ? 'filled' : 'outlined'}
-            />
-          ))}
+          {tabs.map((tab, i) => {
+            const isActive = tab.id === activeTabId;
+            return (
+              <Tooltip key={tab.id} title={tab.path} arrow>
+                <Chip
+                  label={`Tab ${i + 1}: ${formatTabPath(tab.path)}`}
+                  color={isActive ? 'primary' : 'default'}
+                  onClick={() => switchTab(tab.id)}
+                  onDelete={tabs.length > 1 ? () => closeTab(tab.id) : undefined}
+                  variant={isActive ? 'filled' : 'outlined'}
+                  sx={{
+                    fontWeight: isActive ? 700 : 500,
+                    borderWidth: isActive ? 2 : 1,
+                    maxWidth: 280,
+                    '& .MuiChip-label': {
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    },
+                  }}
+                />
+              </Tooltip>
+            );
+          })}
           <Button size="small" onClick={openNewTab}>
             + New Tab
           </Button>

--- a/plan/80_issue160_tab_ux_polish.md
+++ b/plan/80_issue160_tab_ux_polish.md
@@ -1,0 +1,15 @@
+# Issue #160 — Tab UX polish
+
+## Scope
+- Tab path label ellipsis with full-path tooltip
+- Prevent duplicate tab creation for same path
+- Strengthen active tab visual affordance
+
+## Changes
+- Update tab open logic to reuse existing tab when same path exists
+- Add compact path label helper
+- Render each tab chip with tooltip/full path and stronger active styling
+
+## Validation
+- frontend build
+- frontend tests


### PR DESCRIPTION
## Summary
- add tab path ellipsis with full-path tooltip
- prevent duplicate same-path tabs by focusing existing tab instead of creating a new one
- strengthen active-tab visual affordance

## Validation
- npm run build ✅
- npx vitest run ⚠️ existing baseline failures (store/file-table tests)

Closes #160