### PR TITLE
feat(uiux): file table column visibility toggle (issue #164)

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -136,6 +136,18 @@ export const FileBrowser: React.FC = () => {
   const [showHiddenFiles, setShowHiddenFiles] = React.useState(() => {
     return localStorage.getItem('fileBrowser.showHiddenFiles') === 'true';
   });
+  const [visibleColumns, setVisibleColumns] = React.useState(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem('fileBrowser.visibleColumns') ?? '{}');
+      return {
+        size: saved.size ?? true,
+        date: saved.date ?? true,
+        owner: saved.owner ?? window.innerWidth >= 900,
+      };
+    } catch {
+      return { size: true, date: true, owner: window.innerWidth >= 900 };
+    }
+  });
   const [isMoveModalOpen, setIsMoveModalOpen] = React.useState(false);
   const [renameTarget, setRenameTarget] = React.useState<FileNode | null>(null);
   const [renameValue, setRenameValue] = React.useState('');
@@ -286,6 +298,10 @@ export const FileBrowser: React.FC = () => {
       localStorage.setItem('fileBrowser.presetHintDismissed', 'true');
     }
   }, [showPresetHint]);
+
+  React.useEffect(() => {
+    localStorage.setItem('fileBrowser.visibleColumns', JSON.stringify(visibleColumns));
+  }, [visibleColumns]);
 
   React.useEffect(() => {
     setRecentPaths((prev) => {
@@ -780,6 +796,30 @@ export const FileBrowser: React.FC = () => {
         >
           {showHiddenFiles ? 'Hide hidden files' : 'Show hidden files'}
         </Button>
+
+        <Stack direction="row" spacing={0.5}>
+          <Button
+            size="small"
+            variant={visibleColumns.size ? 'contained' : 'outlined'}
+            onClick={() => setVisibleColumns((prev) => ({ ...prev, size: !prev.size }))}
+          >
+            Size
+          </Button>
+          <Button
+            size="small"
+            variant={visibleColumns.date ? 'contained' : 'outlined'}
+            onClick={() => setVisibleColumns((prev) => ({ ...prev, date: !prev.date }))}
+          >
+            Date
+          </Button>
+          <Button
+            size="small"
+            variant={visibleColumns.owner ? 'contained' : 'outlined'}
+            onClick={() => setVisibleColumns((prev) => ({ ...prev, owner: !prev.owner }))}
+          >
+            Owner
+          </Button>
+        </Stack>
       </Stack>
 
       {showPresetHint && (
@@ -928,6 +968,7 @@ export const FileBrowser: React.FC = () => {
               files={visibleFiles}
               onNavigate={navigateTo}
               viewMode={viewMode}
+              visibleColumns={visibleColumns}
               selectedFiles={selectedFiles}
               onSelectionChange={handleSelectionChange}
               onSelectionIntent={handleSelectionIntent}

--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -33,6 +33,11 @@ interface FileTableProps {
   files: FileNode[];
   onNavigate: (name: string) => void;
   viewMode?: ViewMode;
+  visibleColumns?: {
+    size: boolean;
+    date: boolean;
+    owner: boolean;
+  };
   selectedFiles: Set<string>;
   onSelectionChange: (selected: Set<string>) => void;
   onSelectionIntent?: (
@@ -104,6 +109,7 @@ export const FileTable: React.FC<FileTableProps> = ({
   files,
   onNavigate,
   viewMode = 'list',
+  visibleColumns = { size: true, date: true, owner: true },
   selectedFiles,
   onSelectionChange,
   onSelectionIntent,
@@ -419,16 +425,16 @@ export const FileTable: React.FC<FileTableProps> = ({
             </StyledHeaderCell>
             <StyledHeaderCell width="50px"></StyledHeaderCell>
             <StyledHeaderCell>Name</StyledHeaderCell>
-            <StyledHeaderCell align="right">Size</StyledHeaderCell>
-            <StyledHeaderCell align="right">Date</StyledHeaderCell>
-            <StyledHeaderCell align="right">Owner</StyledHeaderCell>
+            {visibleColumns.size && <StyledHeaderCell align="right">Size</StyledHeaderCell>}
+            {visibleColumns.date && <StyledHeaderCell align="right">Date</StyledHeaderCell>}
+            {visibleColumns.owner && <StyledHeaderCell align="right">Owner</StyledHeaderCell>}
           </TableRow>
         </TableHead>
         <TableBody>
           {tableVirtualizer.getVirtualItems().length > 0 && (
             <TableRow>
               <TableCell
-                colSpan={6}
+                colSpan={3 + Number(visibleColumns.size) + Number(visibleColumns.date) + Number(visibleColumns.owner)}
                 sx={{ height: tableVirtualizer.getVirtualItems()[0].start, p: 0, border: 0 }}
               />
             </TableRow>
@@ -492,17 +498,23 @@ export const FileTable: React.FC<FileTableProps> = ({
                 <StyledTableCell component="th" scope="row" sx={{ fontWeight: 500 }}>
                   {file.name}
                 </StyledTableCell>
-                <StyledTableCell align="right">
-                  {file.type === 'DIRECTORY' ? '--' : formatSize(file.size)}
-                </StyledTableCell>
-                <StyledTableCell align="right">
-                  <Tooltip title={formatExactDateTime(file.lastModified)} arrow>
-                    <span>{formatRelativeDateTime(file.lastModified)}</span>
-                  </Tooltip>
-                </StyledTableCell>
-                <StyledTableCell align="right" sx={{ color: 'text.secondary' }}>
-                  {file.owner}
-                </StyledTableCell>
+                {visibleColumns.size && (
+                  <StyledTableCell align="right">
+                    {file.type === 'DIRECTORY' ? '--' : formatSize(file.size)}
+                  </StyledTableCell>
+                )}
+                {visibleColumns.date && (
+                  <StyledTableCell align="right">
+                    <Tooltip title={formatExactDateTime(file.lastModified)} arrow>
+                      <span>{formatRelativeDateTime(file.lastModified)}</span>
+                    </Tooltip>
+                  </StyledTableCell>
+                )}
+                {visibleColumns.owner && (
+                  <StyledTableCell align="right" sx={{ color: 'text.secondary' }}>
+                    {file.owner}
+                  </StyledTableCell>
+                )}
               </StyledTableRow>
             );
           })}
@@ -510,7 +522,7 @@ export const FileTable: React.FC<FileTableProps> = ({
           {tableVirtualizer.getVirtualItems().length > 0 && (
             <TableRow>
               <TableCell
-                colSpan={6}
+                colSpan={3 + Number(visibleColumns.size) + Number(visibleColumns.date) + Number(visibleColumns.owner)}
                 sx={{
                   height:
                     tableVirtualizer.getTotalSize() -

--- a/plan/84_issue164_column_visibility_toggle.md
+++ b/plan/84_issue164_column_visibility_toggle.md
@@ -1,0 +1,10 @@
+# Issue #164 — File table column visibility
+
+## Scope
+- Toggle visibility for Name/Size/Date/Owner columns (Name always kept visible as fallback)
+- Persist preferences in localStorage
+- Responsive fallback: Owner hidden by default on mobile-ish screens
+
+## Validation
+- frontend build
+- frontend tests


### PR DESCRIPTION
## Summary
- add Size/Date/Owner column visibility toggles
- persist preferences in localStorage
- apply responsive default for Owner visibility

## Validation
- npm run build ✅
- npx vitest run ⚠️ existing baseline failures

Closes #164