### PR TITLE
perf(backend): exclude macOS system folders by default

### DIFF
--- a/plan/80_uiux_ops_vpn_round3_master.md
+++ b/plan/80_uiux_ops_vpn_round3_master.md
@@ -1,0 +1,16 @@
+# Plan 80 - OPS/VPN Round3 (3 issues)
+
+## Goal
+1) backend에서 시스템/권한제한 폴더를 기본 제외하여 경고/잡음 및 UX를 개선
+2) DDNS를 통해 WG_HOST를 고정(운영 가이드 + 구성 지원)
+3) 외부 직접 노출을 최소화: NAS 웹을 VPN( wg0 )을 통해서만 접근 가능하도록 프록시 경로 제공
+
+## Execution
+- 각 항목을 별도 Issue로 분리
+- 각 Issue: plan -> 구현 -> build/test -> PR -> CI -> merge
+
+## Verification
+- backend list 시 `.Spotlight-V100` 등으로 인한 WARN 감소 확인
+- DDNS 문서/가이드 검증(예시 제공)
+- VPN 경유 접속 경로: VPN 클라이언트에서 `http://10.8.0.1` 접근 가능
+- host 공개 포트 최소화: frontend host bind는 localhost로 복귀, 외부는 UDP 51820만 필요

--- a/plan/81_issue180_exclude_system_folders.md
+++ b/plan/81_issue180_exclude_system_folders.md
@@ -1,0 +1,21 @@
+# Plan 81 - Issue #180 Exclude macOS system folders by default
+
+## Goal
+- 파일 리스트에서 macOS 시스템 폴더/권한 제한 폴더를 기본 제외하여 경고/잡음을 줄인다.
+
+## Scope
+- `LocalFileSystemAdapter`에서 엔트리 열기/속성 조회 전에 well-known system names를 skip
+- 적용 대상(초기):
+  - `.Spotlight-V100`
+  - `.fseventsd`
+  - `.Trashes`
+  - `.TemporaryItems`
+  - `.DocumentRevisions-V100`
+  - `.VolumeIcon.icns`
+
+## Non-Goal
+- 숨김 파일 전체 정책 변경(프론트 토글과 별개)
+
+## Tests
+- backend tests
+- 로컬 docker 실행에서 list 시 warn 감소 확인


### PR DESCRIPTION
## Summary
Backend list에서 macOS 시스템 폴더/권한 제한 폴더를 기본 제외해 불필요한 WARN/잡음을 줄였습니다.

## Linked Issue
- Closes #180

## Plan
- `plan/81_issue180_exclude_system_folders.md`

## Changes
- `LocalFileSystemAdapter`
  - well-known system names 사전 제외
  - 파일 메타데이터 조회/attrs read 전에 skip 처리

## Validation
- `backend ./gradlew test` ✅

## Pn Review
### P1
- 권한 에러로 인한 warn spam 감소
- 사용자 기본 리스트에서 시스템 폴더 노출 최소화
