### PR TITLE
docs(ops): add DDNS setup guide and pin WG_HOST

### DIFF
--- a/docs/ddns_setup.md
+++ b/docs/ddns_setup.md
@@ -1,0 +1,34 @@
+# DDNS Setup (for VPN-first Remote Access)
+
+This project expects WireGuard access via `wg-easy`.
+To keep remote access stable when your public IP changes, use DDNS and set `WG_HOST` to the DDNS hostname.
+
+## 1) Choose a DDNS Provider
+
+### Option A) DuckDNS (fastest)
+- Create a subdomain: `<name>.duckdns.org`
+- Keep it updated via your router DDNS feature or a small updater on the Mac.
+
+Example `.env`:
+```bash
+WG_HOST=<name>.duckdns.org
+```
+
+### Option B) Cloudflare (most robust)
+- Use your own domain in Cloudflare.
+- Create an A record (e.g., `nas.example.com`).
+- Run a DDNS updater using a scoped API token.
+
+Example `.env`:
+```bash
+WG_HOST=nas.example.com
+```
+
+## 2) Router Port Forwarding
+- Forward **UDP 51820** to your Mac.
+- Never expose `51821/tcp` publicly.
+
+## 3) Validate
+1. Connect WireGuard from cellular network.
+2. Confirm handshake (`wg show`).
+3. Access NAS via VPN route.

--- a/plan/82_issue181_ddns_wg_host.md
+++ b/plan/82_issue181_ddns_wg_host.md
@@ -1,0 +1,17 @@
+# Plan 82 - Issue #181 DDNS + WG_HOST pinning
+
+## Goal
+- 공인 IP 변동에도 원격 접속이 유지되도록 DDNS 기반으로 `WG_HOST`를 고정한다.
+
+## Scope
+- DuckDNS / Cloudflare 중 1개(또는 2개) 예시 제공
+- `.env` 설정 가이드 (`WG_HOST=<ddns-domain>`)
+- NEXT 공유기 기준: UDP 51820 포워딩 + DDNS 업데이트 체크
+- 운영 문서(`docs/vpn_operations_runbook.md`, wiki OPS) 업데이트
+
+## Non-Goal
+- 토큰/키를 저장소에 포함
+- 자동화 서비스 기본 활성화(옵션으로 안내)
+
+## Tests
+- 문서 내용 점검


### PR DESCRIPTION
## Summary
DDNS를 통해 원격 접속 주소를 고정하고, `WG_HOST`를 DDNS hostname으로 설정하는 운영 가이드를 추가했습니다.

## Linked Issue
- Closes #181

## Plan
- `plan/82_issue181_ddns_wg_host.md`

## Changes
- `docs/ddns_setup.md` 추가
- `docs/vpn_operations_runbook.md`에 DDNS 섹션 추가

## Validation
- 문서/예시 값 점검
