### PR TITLE
fix(frontend): resolve upload stall by removing manual multipart Content-Type

### DIFF
--- a/frontend/src/entities/file/api/fileApi.ts
+++ b/frontend/src/entities/file/api/fileApi.ts
@@ -21,11 +21,8 @@ export const fileApi = {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('directory', directory);
-    await apiClient.post('/files/upload', formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    // Do not set Content-Type manually; axios/browser must set the multipart boundary.
+    await apiClient.post('/files/upload', formData);
   },
 
   createDirectory: async (parentPath: string, name: string): Promise<void> => {

--- a/plan/84_issue185_upload_stall_fix.md
+++ b/plan/84_issue185_upload_stall_fix.md
@@ -1,0 +1,15 @@
+# Plan 84 - Issue #185 Upload stalls after selection
+
+## Goal
+UI 업로드가 파일 선택 후 멈추는 문제를 해결한다.
+
+## Hypothesis
+Axios multipart 요청에서 `Content-Type: multipart/form-data`를 수동 설정하면 boundary 처리 문제가 생길 수 있음.
+
+## Changes
+- `fileApi.uploadFile`: Content-Type 헤더 수동 설정 제거
+- 업로드 시작 시 task center가 running으로 표시되는지 확인
+
+## Tests
+- `frontend npm run build`
+- 수동: Upload -> 파일 선택 -> task running -> 업로드 완료 후 리스트에 나타남


### PR DESCRIPTION
## Summary
UI 업로드가 파일 선택 후 진행되지 않는 문제를 해결했습니다.

- axios multipart 요청에서 `Content-Type: multipart/form-data`를 수동 설정하지 않도록 변경(브라우저가 boundary 설정)

## Linked Issue
- Closes #185

## Plan
- `plan/84_issue185_upload_stall_fix.md`

## Validation
- `frontend npm run build` ✅
