### PR TITLE
feat(ops): VPN-only proxy entrypoint for NAS web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,19 @@ services:
     networks:
       - nas_network
 
+  nas-vpn-proxy:
+    build: ./vpn-proxy
+    container_name: nas-vpn-proxy
+    network_mode: "service:wg-easy"
+    depends_on:
+      wg-easy:
+        condition: service_started
+      nas-frontend:
+        condition: service_healthy
+      nas-backend:
+        condition: service_healthy
+    restart: unless-stopped
+
 networks:
   nas_network:
     driver: bridge

--- a/plan/83_issue182_vpn_only_proxy.md
+++ b/plan/83_issue182_vpn_only_proxy.md
@@ -1,0 +1,17 @@
+# Plan 83 - Issue #182 VPN-only proxy for NAS web
+
+## Goal
+- NAS 웹 UI를 VPN(wg0) 경유로만 접근 가능하도록 구성하고, host 직접 노출을 최소화한다.
+
+## Design
+- `nas-frontend`는 host에서 `127.0.0.1:80`로만 바인딩(로컬 전용)
+- `nas-vpn-proxy`(nginx) 컨테이너를 추가하여 `network_mode: service:wg-easy`로 wg-easy 네임스페이스(wg0)에서 80 리슨
+- VPN 클라이언트는 `http://10.8.0.1`로 접속
+- Proxy 라우팅:
+  - `/api/*` -> `nas-backend:8080`
+  - 그 외 -> `nas-frontend:80`
+
+## Validation
+- host에서 0.0.0.0:80 미노출 확인
+- `docker exec nas-vpn curl http://127.0.0.1` (proxy) 200 확인
+- 기존 로컬 개발은 `http://127.0.0.1/` 유지

--- a/vpn-proxy/Dockerfile
+++ b/vpn-proxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+RUN apk add --no-cache curl
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/vpn-proxy/nginx.conf
+++ b/vpn-proxy/nginx.conf
@@ -1,0 +1,22 @@
+server {
+  listen 80;
+  server_name _;
+
+  # VPN-only entrypoint (runs inside wg-easy netns)
+
+  location /api/ {
+    proxy_pass http://nas-backend:8080/api/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location / {
+    proxy_pass http://nas-frontend:80/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}


### PR DESCRIPTION
## Summary
NAS 웹을 VPN 경유로만 접근하도록 경로를 추가하고, host 직접 노출을 최소화했습니다.

- host: `nas-frontend`는 기본적으로 `127.0.0.1:80` 바인딩 유지
- VPN: `nas-vpn-proxy`가 wg-easy 네임스페이스(wg0)에서 80을 리슨하여 VPN 클라이언트는 `http://10.8.0.1`로 접속

## Linked Issue
- Closes #182

## Plan
- `plan/83_issue182_vpn_only_proxy.md`

## Validation
- `nas-vpn-proxy`에서 `/` 200 확인
- `/api/*`는 인증 없으면 403(정상)

## Notes
- VPN 클라이언트는 NAS URL을 `http://10.8.0.1`로 사용 권장
