### PR TITLE
chore(ops): standardize VPN proxy health checks

### DIFF
--- a/docs/vpn_operations_runbook.md
+++ b/docs/vpn_operations_runbook.md
@@ -27,12 +27,24 @@
   4. Validate peer connectivity and admin UI.
   5. Rollback by restoring previous version value if needed.
 
-## 4) Post-Change Validation Checklist
+## 4) VPN Proxy Validation (VPN-only entrypoint)
+
+If you use the VPN-only proxy entrypoint (`nas-vpn-proxy`), validate reachability from inside the VPN namespace:
+
+```bash
+bash scripts/check_vpn_proxy.sh
+```
+
+Expected:
+- `/` -> 200
+- `/api/admin/system/health` -> 401/403 (unauth) or 200 (auth)
+
+## 5) Post-Change Validation Checklist
 - [ ] UDP 51820 reachable only as intended.
 - [ ] 51821 admin UI not publicly exposed.
 - [ ] VPN client can access NAS services.
 - [ ] Unauthorized client cannot connect.
 - [ ] Change record updated.
 
-## 5) Emergency Contacts / Notes
+## 6) Emergency Contacts / Notes
 - Keep this section updated with operator-specific procedures.

--- a/plan/86_issue190_vpn_proxy_healthcheck.md
+++ b/plan/86_issue190_vpn_proxy_healthcheck.md
@@ -1,0 +1,14 @@
+# Plan 86 - Issue #190 VPN proxy healthcheck standardization
+
+## Goal
+- VPN 경유 검증을 `nas-vpn-proxy` 기준으로 표준화하고 wg-easy 컨테이너 내부 도구(curl) 의존을 제거한다.
+
+## Scope
+- `scripts/check_vpn_proxy.sh` 추가
+  - nas-vpn-proxy에서 `http://127.0.0.1/` 200
+  - nas-vpn-proxy에서 `http://127.0.0.1/api/admin/system/health` 403(unauth) 또는 200(auth) 허용
+- `docs/vpn_operations_runbook.md`에 검증 커맨드 추가
+
+## Tests
+- `bash scripts/check_vpn_proxy.sh`
+- `docker compose up -d --build`

--- a/scripts/check_vpn_proxy.sh
+++ b/scripts/check_vpn_proxy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1"; exit 1; }
+}
+
+require_cmd docker
+require_cmd curl
+
+if ! docker ps --format '{{.Names}}' | grep -q '^nas-vpn-proxy$'; then
+  echo "nas-vpn-proxy container not running"
+  exit 1
+fi
+
+echo "[1/2] vpn proxy root check"
+code=$(docker exec nas-vpn-proxy sh -lc "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1/")
+if [[ "$code" != "200" ]]; then
+  echo "expected 200 from vpn proxy root, got: $code"
+  exit 1
+fi
+
+echo "[2/2] vpn proxy API unauth check"
+code=$(docker exec nas-vpn-proxy sh -lc "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1/api/admin/system/health")
+# unauth can be 401/403 depending on security config
+if [[ "$code" != "401" && "$code" != "403" && "$code" != "200" ]]; then
+  echo "unexpected status from vpn proxy api health, got: $code"
+  exit 1
+fi
+
+echo "VPN_PROXY_CHECK_OK"


### PR DESCRIPTION
## Summary
VPN proxy 경유 검증을 `nas-vpn-proxy` 기준으로 표준화했습니다.

- `scripts/check_vpn_proxy.sh` 추가
- Runbook에 VPN proxy validation 섹션 추가

## Linked Issue
- Closes #190

## Plan
- `plan/86_issue190_vpn_proxy_healthcheck.md`

## Validation
- `bash scripts/check_vpn_proxy.sh` ✅
