### PR TITLE
fix(frontend): remove global JSON Content-Type to stop upload 415

### DIFF
--- a/frontend/src/shared/api/axios.ts
+++ b/frontend/src/shared/api/axios.ts
@@ -8,9 +8,6 @@ export const API_URL = '/api';
 
 export const apiClient = axios.create({
   baseURL: API_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  },
   withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- remove global `Content-Type: application/json` from shared axios client
- allow browser/axios to set multipart boundary automatically for FormData uploads

## Why
Upload endpoint started returning `415 Unsupported Media Type` due to global JSON header interfering with multipart requests.

## Related
Closes #193

## Validation
- rebuilt frontend container
- verified upload request path no longer forces JSON content-type
