### PR TITLE
feat(file-browser): stabilize DnD move and Task Center retry

### DIFF
--- a/backend/src/main/java/com/manas/backend/context/file/infrastructure/fs/LocalFileSystemAdapter.java
+++ b/backend/src/main/java/com/manas/backend/context/file/infrastructure/fs/LocalFileSystemAdapter.java
@@ -275,9 +275,24 @@ public class LocalFileSystemAdapter implements FileStoragePort {
             ".VolumeIcon.icns"
     );
 
+    private static final Set<String> ROOT_VOLUME_EXCLUDES = Set.of(
+            "Macintosh HD",
+            "Macintosh HD - Data"
+    );
+
     private boolean shouldExcludeByDefault(Path path) {
         String name = path.getFileName() == null ? "" : path.getFileName().toString();
-        return DEFAULT_SYSTEM_EXCLUDES.contains(name);
+
+        if (DEFAULT_SYSTEM_EXCLUDES.contains(name)) {
+            return true;
+        }
+
+        Path parent = path.getParent();
+        if (parent != null && parent.equals(rootPath) && ROOT_VOLUME_EXCLUDES.contains(name)) {
+            return true;
+        }
+
+        return false;
     }
 
     private List<PathEntry> fetchEntriesSortedByName(Path directory, FileListSort sort) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -40,6 +40,11 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: true
 
+  servlet:
+    multipart:
+      max-file-size: 1GB
+      max-request-size: 1GB
+
 jwt:
   secret: ${JWT_SECRET}
   expiration: 86400000

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,7 @@
 server {
     listen 80;
     server_name localhost;
+    client_max_body_size 1g;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/frontend/src/features/file-actions/model/useFileActions.ts
+++ b/frontend/src/features/file-actions/model/useFileActions.ts
@@ -13,7 +13,13 @@ export const useFileActions = () => {
 
   const deleteFilesMutation = useMutation({
     mutationFn: async (paths: string[]) => {
-      const taskId = startTask({type: 'file.delete', count: paths.length});
+      const taskId = startTask({
+        task: {type: 'file.delete', count: paths.length},
+        onRetry: async () => {
+          await fileApi.deleteFiles(paths);
+          queryClient.invalidateQueries({queryKey: queryKeys.files(), exact: false});
+        },
+      });
       try {
         const result = await fileApi.deleteFiles(paths);
         completeTask(taskId);
@@ -53,7 +59,13 @@ export const useFileActions = () => {
 
   const uploadFileMutation = useMutation({
     mutationFn: async ({file, directory}: { file: File; directory: string }) => {
-      const taskId = startTask({type: 'file.upload', fileName: file.name});
+      const taskId = startTask({
+        task: {type: 'file.upload', fileName: file.name},
+        onRetry: async () => {
+          await fileApi.uploadFile(file, directory);
+          queryClient.invalidateQueries({queryKey: queryKeys.files(), exact: false});
+        },
+      });
       try {
         const result = await fileApi.uploadFile(file, directory);
         completeTask(taskId);
@@ -71,7 +83,13 @@ export const useFileActions = () => {
 
   const createDirectoryMutation = useMutation({
     mutationFn: async ({parentPath, name}: { parentPath: string; name: string }) => {
-      const taskId = startTask({type: 'file.mkdir', fileName: name});
+      const taskId = startTask({
+        task: {type: 'file.mkdir', fileName: name},
+        onRetry: async () => {
+          await fileApi.createDirectory(parentPath, name);
+          queryClient.invalidateQueries({queryKey: queryKeys.files(), exact: false});
+        },
+      });
       try {
         const result = await fileApi.createDirectory(parentPath, name);
         completeTask(taskId);
@@ -89,7 +107,15 @@ export const useFileActions = () => {
 
   const moveFilesBatchMutation = useMutation({
     mutationFn: async (moves: Array<{ sourcePath: string; destinationPath: string }>) => {
-      const taskId = startTask(`Move ${moves.length} item(s)`);
+      const taskId = startTask({
+        task: `Move ${moves.length} item(s)`,
+        onRetry: async () => {
+          for (const move of moves) {
+            await fileApi.moveFile(move.sourcePath, move.destinationPath);
+          }
+          queryClient.invalidateQueries({queryKey: queryKeys.files(), exact: false});
+        },
+      });
       let successCount = 0;
       const failures: Array<{ sourcePath: string; reason: string }> = [];
 
@@ -122,7 +148,13 @@ export const useFileActions = () => {
 
   const moveFileMutation = useMutation({
     mutationFn: async ({sourcePath, destinationPath}: { sourcePath: string; destinationPath: string }) => {
-      const taskId = startTask({type: 'file.move', sourcePath, destinationPath});
+      const taskId = startTask({
+        task: {type: 'file.move', sourcePath, destinationPath},
+        onRetry: async () => {
+          await fileApi.moveFile(sourcePath, destinationPath);
+          queryClient.invalidateQueries({queryKey: queryKeys.files(), exact: false});
+        },
+      });
       try {
         const result = await fileApi.moveFile(sourcePath, destinationPath);
         completeTask(taskId);

--- a/frontend/src/features/file-actions/ui/FileActionsToolbar.tsx
+++ b/frontend/src/features/file-actions/ui/FileActionsToolbar.tsx
@@ -28,7 +28,7 @@ interface FileActionsToolbarProps {
   selectedFiles: Set<string>;
   currentPath: string;
   onClearSelection: () => void;
-  onRefresh?: () => void;
+  onRefresh?: () => void | Promise<unknown>;
 }
 
 export const FileActionsToolbar: React.FC<FileActionsToolbarProps> = ({
@@ -59,6 +59,7 @@ export const FileActionsToolbar: React.FC<FileActionsToolbarProps> = ({
     if (paths.length === 0) return;
 
     await deleteFiles(paths);
+    await onRefresh?.();
     onClearSelection();
     setIsDeleteConfirmOpen(false);
   };
@@ -84,6 +85,9 @@ export const FileActionsToolbar: React.FC<FileActionsToolbarProps> = ({
       for (let i = 0; i < files.length; i++) {
         await uploadFile({file: files[i], directory: currentPath});
       }
+
+      // Ensure visible list refreshes immediately after upload completes.
+      await onRefresh?.();
     }
     // Reset input
     if (fileInputRef.current) {
@@ -104,6 +108,7 @@ export const FileActionsToolbar: React.FC<FileActionsToolbarProps> = ({
     if (error) return;
 
     await createDirectory({parentPath: currentPath, name: newDirectoryName.trim()});
+    await onRefresh?.();
     setIsCreateDirModalOpen(false);
     setNewDirectoryName('');
   };

--- a/vpn-proxy/nginx.conf
+++ b/vpn-proxy/nginx.conf
@@ -1,6 +1,7 @@
 server {
   listen 80;
   server_name _;
+  client_max_body_size 1g;
 
   # VPN-only entrypoint (runs inside wg-easy netns)
 


### PR DESCRIPTION
## Summary
- make file drag-and-drop move reliable for selected files -> directory targets
- add moving interaction overlay during drop-move operation
- make Task Center Retry actually re-execute failed operations
- ensure upload/delete/create-directory triggers immediate list refresh
- raise upload/request limits to 1GB (frontend nginx / vpn-proxy / backend multipart)
- hide root volume system entries and constrain storage root behavior
- improve checkbox multi-select UX (no Cmd/Ctrl requirement)

## Related
Closes #195

## Validation
- rebuilt/restarted frontend/backend/proxy containers
- verified drag metadata fallback + drop handling path
- verified retry action calls real mutation path
