### PR TITLE
Fix missing auto-refresh after Move modal action

### DIFF
--- a/frontend/src/features/file-actions/ui/FileActionsToolbar.tsx
+++ b/frontend/src/features/file-actions/ui/FileActionsToolbar.tsx
@@ -268,7 +268,10 @@ export const FileActionsToolbar: React.FC<FileActionsToolbarProps> = ({
                   onClose={() => setIsMoveModalOpen(false)}
                   selectedFiles={selectedFiles}
                   sourceDirectory={currentPath}
-                  onSuccess={onClearSelection}
+                  onSuccess={async () => {
+                    onClearSelection();
+                    await onRefresh?.();
+                  }}
               />
 
               <Dialog open={isDeleteConfirmOpen} onClose={() => setIsDeleteConfirmOpen(false)} fullWidth maxWidth="xs">

--- a/frontend/src/features/file-actions/ui/MoveFileModal.tsx
+++ b/frontend/src/features/file-actions/ui/MoveFileModal.tsx
@@ -8,7 +8,7 @@ interface MoveFileModalProps {
   onClose: () => void;
   selectedFiles: Set<string>;
   sourceDirectory: string;
-  onSuccess: () => void;
+  onSuccess: () => void | Promise<void>;
 }
 
 export const MoveFileModal: React.FC<MoveFileModalProps> = ({
@@ -39,7 +39,7 @@ export const MoveFileModal: React.FC<MoveFileModalProps> = ({
 
         await moveFile({sourcePath: source, destinationPath: destination});
       }
-      onSuccess();
+      await onSuccess();
       onClose();
     } catch (error) {
       console.error("Failed to move files", error);

--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -1190,9 +1190,9 @@ export const FileBrowser: React.FC = () => {
           selectedFiles.size > 0 ? selectedFiles : new Set(focusedFile ? [focusedFile.name] : [])
         }
         sourceDirectory={currentPath}
-        onSuccess={() => {
+        onSuccess={async () => {
           clearSelection();
-          setIsMoveModalOpen(false);
+          await refetch();
         }}
       />
 


### PR DESCRIPTION
## Summary
Move 모달로 파일 이동 후 목록이 자동 새로고침되지 않는 문제를 수정했습니다.

## Changes
- `MoveFileModal`의 `onSuccess` 타입을 `() => void | Promise<void>`로 확장
- move 완료 후 `await onSuccess()` 호출로 상위 리프레시 완료 보장
- `FileActionsToolbar`의 Move 성공 콜백에서 `onRefresh?.()` 실행
- `FileBrowser` 상세/컨텍스트 Move 모달 성공 콜백에서 `await refetch()` 실행

## Validation
- frontend build 통과
- Move 버튼 경로에서 이동 직후 목록 갱신 동작 확인

Closes #199
