### PR TITLE
Fix root move issue by resetting Move modal destination on open

### DIFF
--- a/frontend/src/features/file-actions/ui/MoveFileModal.tsx
+++ b/frontend/src/features/file-actions/ui/MoveFileModal.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Button, Dialog, DialogActions, DialogContent, DialogTitle,} from '@mui/material';
 import {FolderPicker} from './folder-picker/FolderPicker';
 import {useFileActions} from '../model/useFileActions';
@@ -20,6 +20,12 @@ export const MoveFileModal: React.FC<MoveFileModalProps> = ({
                                                             }) => {
   const [destinationPath, setDestinationPath] = useState('/');
   const {moveFile, isMoving} = useFileActions();
+
+  useEffect(() => {
+    if (open) {
+      setDestinationPath('/');
+    }
+  }, [open]);
 
   const handleMove = async () => {
     // Iterate and move each file


### PR DESCRIPTION
## Summary
Move 모달 재오픈 시 이전 대상 경로가 유지되어 하위 디렉토리 -> 루트 이동이 실패/무시되는 문제를 수정했습니다.

## Changes
- `MoveFileModal`에서 `useEffect`로 `open` 상태를 감시
- 모달이 열릴 때마다 `destinationPath`를 `/`로 초기화

## Validation
- frontend build 통과
- 하위 디렉토리에서 Move 모달로 루트 이동 시 정상 동작 기대

Closes #201
