### PR TITLE
Polish favorites/recent paths panel to prevent broken layout

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -696,50 +696,51 @@ export const FileBrowser: React.FC = () => {
 
       {data && (
         <Paper variant="outlined" sx={{ mb: 2, p: 1.5, borderRadius: 2 }}>
-          <Stack direction={{ xs: 'column', md: 'row' }} spacing={3}>
-            <Box sx={{ minWidth: { md: 240 } }}>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'flex-start' }}>
+            <Box sx={{ minWidth: { md: 220 }, flex: 1 }}>
               <Typography variant="subtitle2" sx={{ mb: 1 }}>
                 Favorites
               </Typography>
-              <Stack spacing={0.5}>
-                {favorites.length === 0 ? (
-                  <Typography variant="caption" color="text.secondary">
-                    No favorites yet
-                  </Typography>
-                ) : (
-                  favorites.map((p) => (
-                    <Button
+              {favorites.length === 0 ? (
+                <Typography variant="caption" color="text.secondary">
+                  No favorites yet
+                </Typography>
+              ) : (
+                <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" sx={{ maxHeight: 72, overflowY: 'auto' }}>
+                  {favorites.map((p) => (
+                    <Chip
                       key={p}
                       size="small"
-                      variant="text"
-                      sx={{ justifyContent: 'flex-start' }}
+                      label={p}
+                      clickable
                       onClick={() => navigateToPath(p)}
-                    >
-                      {p}
-                    </Button>
-                  ))
-                )}
-              </Stack>
+                      sx={{ maxWidth: 220 }}
+                    />
+                  ))}
+                </Stack>
+              )}
             </Box>
-            <Box sx={{ minWidth: { md: 280 } }}>
+
+            <Box sx={{ minWidth: { md: 280 }, flex: 1.4 }}>
               <Typography variant="subtitle2" sx={{ mb: 1 }}>
                 Recent paths
               </Typography>
-              <Stack spacing={0.5}>
+              <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" sx={{ maxHeight: 72, overflowY: 'auto' }}>
                 {recentPaths.map((p) => (
-                  <Button
+                  <Chip
                     key={p}
                     size="small"
-                    variant="text"
-                    sx={{ justifyContent: 'flex-start' }}
+                    variant="outlined"
+                    label={p}
+                    clickable
                     onClick={() => navigateToPath(p)}
-                  >
-                    {p}
-                  </Button>
+                    sx={{ maxWidth: 240 }}
+                  />
                 ))}
               </Stack>
             </Box>
-            <Stack spacing={1} sx={{ display: 'flex', alignItems: 'flex-start' }}>
+
+            <Stack direction={{ xs: 'row', md: 'row' }} spacing={1} useFlexGap flexWrap="wrap" sx={{ minWidth: { md: 320 }, justifyContent: { xs: 'flex-start', md: 'flex-end' } }}>
               <Button
                 size="small"
                 variant={favorites.includes(currentPath) ? 'contained' : 'outlined'}


### PR DESCRIPTION
## Summary
Favorites / Recent paths 카드가 세로로 길어져 화면이 깨져 보이는 문제를 완화했습니다.

## Changes
- 경로 목록을 텍스트 버튼 목록에서 compact chip 목록으로 변경
- favorites/recent 목록 영역에 `maxHeight + overflowY` 적용
- 우측 액션 버튼(즐겨찾기/휴지통) 배치를 가로 정렬로 정리
- 카드 전체 spacing 정리

## Validation
- frontend build 통과
- 경로가 여러 개일 때 카드 높이가 과도하게 늘어나지 않는지 확인

Closes #203
