### PR TITLE
Improve DnD move UX continuity with live drag feedback

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -115,6 +115,7 @@ export const FileBrowser: React.FC = () => {
   const [contextAnchor, setContextAnchor] = React.useState<null | HTMLElement>(null);
   const [isDropzoneActive, setIsDropzoneActive] = React.useState(false);
   const [draggingCount, setDraggingCount] = React.useState(0);
+  const [dragHoverTarget, setDragHoverTarget] = React.useState<string | null>(null);
   const [dropMoveState, setDropMoveState] = React.useState<{count: number; target: string} | null>(null);
   const [favorites, setFavorites] = React.useState<string[]>(() => {
     try {
@@ -531,9 +532,11 @@ export const FileBrowser: React.FC = () => {
 
       await moveFilesBatch(moves);
       setDraggingCount(0);
+      setDragHoverTarget(null);
       clearSelection();
     } finally {
       setDropMoveState(null);
+      setDragHoverTarget(null);
     }
   };
 
@@ -552,6 +555,7 @@ export const FileBrowser: React.FC = () => {
     event.preventDefault();
     setIsDropzoneActive(false);
     setDraggingCount(0);
+    setDragHoverTarget(null);
 
     const droppedFiles = Array.from(event.dataTransfer.files);
     for (const file of droppedFiles) {
@@ -689,9 +693,34 @@ export const FileBrowser: React.FC = () => {
       )}
 
       {draggingCount > 0 && (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          Dragging {draggingCount} item(s). Drop on a folder to move.
-        </Alert>
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 8,
+            zIndex: 20,
+            mb: 2,
+            pointerEvents: 'none',
+          }}
+        >
+          <Paper
+            elevation={4}
+            sx={{
+              px: 1.5,
+              py: 1,
+              borderRadius: 2,
+              border: `1px solid ${dragHoverTarget ? '#2e7d32' : '#90caf9'}`,
+              backgroundColor: dragHoverTarget ? 'rgba(46,125,50,0.08)' : 'rgba(33,150,243,0.08)',
+              transition: 'all 180ms ease',
+            }}
+          >
+            <Typography variant="body2" sx={{ fontWeight: 700 }}>
+              Moving {draggingCount} item(s)
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {dragHoverTarget ? `Drop to: ${dragHoverTarget}` : 'Drag over a folder to choose destination'}
+            </Typography>
+          </Paper>
+        </Box>
       )}
 
       {data && (
@@ -1032,6 +1061,7 @@ export const FileBrowser: React.FC = () => {
                 void handleDropToDirectory(sourceNames, targetDirectoryName);
               }}
               onDragSelectionCountChange={setDraggingCount}
+              onDragHoverDirectoryChange={setDragHoverTarget}
             />
           </Box>
 

--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -48,6 +48,7 @@ interface FileTableProps {
   onContextMenu?: (event: React.MouseEvent, file: FileNode) => void;
   onDropToDirectory?: (sourceNames: string[], targetDirectoryName: string) => void;
   onDragSelectionCountChange?: (count: number) => void;
+  onDragHoverDirectoryChange?: (directoryName: string | null) => void;
 }
 
 const StyledTableRow = styled(TableRow)(({ theme }) => ({
@@ -118,10 +119,15 @@ export const FileTable: React.FC<FileTableProps> = ({
   onContextMenu,
   onDropToDirectory,
   onDragSelectionCountChange,
+  onDragHoverDirectoryChange,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [dragOverDir, setDragOverDir] = React.useState<string | null>(null);
+  const updateDragOverDir = React.useCallback((name: string | null) => {
+    setDragOverDir(name);
+    onDragHoverDirectoryChange?.(name);
+  }, [onDragHoverDirectoryChange]);
   const [gestureDragActive, setGestureDragActive] = React.useState(false);
   const [gestureDragSourceNames, setGestureDragSourceNames] = React.useState<string[] | null>(null);
   const pointerCandidateRef = React.useRef<{x: number; y: number; file: FileNode} | null>(null);
@@ -202,14 +208,14 @@ export const FileTable: React.FC<FileTableProps> = ({
   };
 
   const handleDragEnd = () => {
-    setDragOverDir(null);
+    updateDragOverDir(null);
     onDragSelectionCountChange?.(0);
   };
 
   const endGestureDrag = React.useCallback(() => {
     setGestureDragActive(false);
     setGestureDragSourceNames(null);
-    setDragOverDir(null);
+    updateDragOverDir(null);
     onDragSelectionCountChange?.(0);
   }, [onDragSelectionCountChange]);
 
@@ -249,7 +255,7 @@ export const FileTable: React.FC<FileTableProps> = ({
 
   const maybeSetGestureTarget = (file: FileNode) => {
     if (!gestureDragActive || file.type !== 'DIRECTORY') return;
-    setDragOverDir(file.name);
+    updateDragOverDir(file.name);
   };
 
   const getDragProps = (file: FileNode) => ({
@@ -262,7 +268,7 @@ export const FileTable: React.FC<FileTableProps> = ({
     if (!onDropToDirectory) return;
     event.preventDefault();
     event.stopPropagation();
-    setDragOverDir(directoryName);
+    updateDragOverDir(directoryName);
     event.dataTransfer.dropEffect = 'move';
   };
 
@@ -270,14 +276,14 @@ export const FileTable: React.FC<FileTableProps> = ({
     if (!onDropToDirectory) return;
     event.preventDefault();
     event.stopPropagation();
-    setDragOverDir(directoryName);
+    updateDragOverDir(directoryName);
   };
 
   const handleDropDirectory = (event: React.DragEvent, directoryName: string) => {
     if (!onDropToDirectory) return;
     event.preventDefault();
     event.stopPropagation();
-    setDragOverDir(null);
+    updateDragOverDir(null);
 
     const raw =
       event.dataTransfer.getData('application/x-nas-file-names') ||
@@ -331,7 +337,7 @@ export const FileTable: React.FC<FileTableProps> = ({
                 onDragOver={(e) =>
                   file.type === 'DIRECTORY' && handleDragOverDirectory(e, file.name)
                 }
-                onDragLeave={() => setDragOverDir(null)}
+                onDragLeave={() => updateDragOverDir(null)}
                 onDropCapture={(e) =>
                   file.type === 'DIRECTORY' && handleDropDirectory(e, file.name)
                 }
@@ -417,7 +423,7 @@ export const FileTable: React.FC<FileTableProps> = ({
                   onDragOver={(e) =>
                     file.type === 'DIRECTORY' && handleDragOverDirectory(e, file.name)
                   }
-                  onDragLeave={() => setDragOverDir(null)}
+                  onDragLeave={() => updateDragOverDir(null)}
                   onDropCapture={(e) =>
                     file.type === 'DIRECTORY' && handleDropDirectory(e, file.name)
                   }
@@ -544,7 +550,7 @@ export const FileTable: React.FC<FileTableProps> = ({
                 onDragOver={(e) =>
                   file.type === 'DIRECTORY' && handleDragOverDirectory(e, file.name)
                 }
-                onDragLeave={() => setDragOverDir(null)}
+                onDragLeave={() => updateDragOverDir(null)}
                 onDropCapture={(e) =>
                   file.type === 'DIRECTORY' && handleDropDirectory(e, file.name)
                 }


### PR DESCRIPTION
## Summary
드래그 앤 드랍 이동 UX의 연속성을 높이기 위해 드래그 중 인터랙션 피드백을 강화했습니다.

## Changes
- `FileTable`에 `onDragHoverDirectoryChange` 콜백 추가
- 드래그 hover 디렉토리를 상위(`FileBrowser`)로 전달
- `FileBrowser`에 sticky drag HUD 추가
  - 이동 아이템 수 표시
  - hover 중인 대상 폴더 실시간 표시
  - 상태에 따라 배경/테두리 색상 전환
- 드롭/취소 시 hover 상태 정리 로직 보강

## Validation
- frontend build 통과
- 드래그 중 상태 피드백이 끊기지 않고 연속적으로 표시되는지 확인

Closes #205
