### PR TITLE
Fix Open Trash error by creating .trash before navigation

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -572,6 +572,11 @@ export const FileBrowser: React.FC = () => {
     await refetch();
   };
 
+  const handleOpenTrash = async () => {
+    await ensureTrashDirectory();
+    navigateToPath(TRASH_PATH);
+  };
+
   return (
     <Box
       onDragOver={handleDragOverBrowser}
@@ -783,7 +788,7 @@ export const FileBrowser: React.FC = () => {
                 size="small"
                 variant={isTrashView ? 'contained' : 'outlined'}
                 color={isTrashView ? 'warning' : 'inherit'}
-                onClick={() => navigateToPath(TRASH_PATH)}
+                onClick={() => void handleOpenTrash()}
               >
                 Open Trash
               </Button>


### PR DESCRIPTION
## Summary
`Open Trash` 클릭 시 `.trash` 경로가 없는 환경에서 발생하던 오류를 수정했습니다.

## Changes
- `FileBrowser`에 `handleOpenTrash` 추가
- 버튼 클릭 시 `ensureTrashDirectory()` 먼저 실행
- 이후 `navigateToPath('/.trash')` 수행

## Validation
- frontend build 통과
- `.trash` 미존재 상태에서도 Open Trash 진입 가능

Closes #207
