### PR TITLE
Add scale+pulse animation for DnD drop target clarity

### DIFF
--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -305,11 +305,27 @@ export const FileTable: React.FC<FileTableProps> = ({
     outline: `2px dashed ${theme.palette.primary.main}`,
     backgroundColor: `${theme.palette.primary.main}14`,
     boxShadow: `0 0 0 2px ${theme.palette.primary.main}22 inset`,
-    animation: 'dndPulse 900ms ease-in-out infinite',
-    '@keyframes dndPulse': {
-      '0%': { boxShadow: `0 0 0 1px ${theme.palette.primary.main}22 inset` },
-      '50%': { boxShadow: `0 0 0 4px ${theme.palette.primary.main}3d inset` },
-      '100%': { boxShadow: `0 0 0 1px ${theme.palette.primary.main}22 inset` },
+    transform: 'scale(1.01)',
+    transformOrigin: 'center',
+    transition: 'transform 140ms ease, background-color 140ms ease, box-shadow 140ms ease',
+    animation: 'dndPulseScale 900ms ease-in-out infinite',
+    '@keyframes dndPulseScale': {
+      '0%': {
+        boxShadow: `0 0 0 1px ${theme.palette.primary.main}22 inset`,
+        transform: 'scale(1.005)',
+      },
+      '50%': {
+        boxShadow: `0 0 0 5px ${theme.palette.primary.main}3d inset`,
+        transform: 'scale(1.016)',
+      },
+      '100%': {
+        boxShadow: `0 0 0 1px ${theme.palette.primary.main}22 inset`,
+        transform: 'scale(1.005)',
+      },
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      animation: 'none',
+      transform: 'none',
     },
   };
 


### PR DESCRIPTION
## Summary
드래그 타겟 폴더 강조에 scale + pulse 애니메이션을 추가해 시인성을 강화했습니다.

## Changes
- 드래그 hover 타겟에 미세 scale-up 효과 적용
- pulse(box-shadow)와 scale을 결합한 `dndPulseScale` 키프레임 적용
- `prefers-reduced-motion` 환경에서는 애니메이션 비활성화

## Validation
- frontend build 통과
- 드래그 중 타겟 폴더 식별성 개선 확인

Closes #211
