### PR TITLE
Fix row shift on selection by narrowing drag source to files

### DIFF
--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -281,8 +281,11 @@ export const FileTable: React.FC<FileTableProps> = ({
   }, [gestureDragActive, activeDragNames.size, endGestureDrag]);
 
   const getDragProps = (file: FileNode) => ({
-    draggable: true,
-    onDragStart: (e: React.DragEvent) => handleDragStart(e, file),
+    draggable: file.type === 'FILE',
+    onDragStart: (e: React.DragEvent) => {
+      if (file.type !== 'FILE') return;
+      handleDragStart(e, file);
+    },
     onDragEnd: handleDragEnd,
   });
 
@@ -473,9 +476,7 @@ export const FileTable: React.FC<FileTableProps> = ({
               <Box key={file.name}>
                 <GridItemCard
                   selected={isSelected}
-                  draggable
-                  onDragStart={(e) => handleDragStart(e, file)}
-                  onDragEnd={handleDragEnd}
+                  {...getDragProps(file)}
                   onDragEnter={(e) =>
                     file.type === 'DIRECTORY' && handleDragEnterDirectory(e, file.name)
                   }


### PR DESCRIPTION
## Summary
파일/디렉토리 선택 시 행이 밀려 보이며 클릭이 어려운 문제를 수정했습니다.

## Changes
- 드래그 소스를 `FILE` 타입으로 제한
- `onDragStart`에서 파일이 아닌 경우 즉시 무시
- GridItemCard도 공통 drag props를 사용하도록 정리

## Why
디렉토리까지 draggable 상태였던 탓에 선택 클릭 동작과 드래그 제스처가 충돌해 레이아웃이 흔들리는 체감이 발생했습니다.

## Validation
- frontend build 통과
- 파일/디렉토리 선택 시 레이아웃 점프 없이 클릭 가능

Closes #219
