### PR TITLE
Allow directories as drag sources in file browser

### DIFF
--- a/frontend/src/widgets/file-table/ui/FileTable.tsx
+++ b/frontend/src/widgets/file-table/ui/FileTable.tsx
@@ -259,7 +259,7 @@ export const FileTable: React.FC<FileTableProps> = ({
   }, [onDragSelectionCountChange, updateDragOverDir]);
 
   const beginPointerCandidate = (event: React.PointerEvent, file: FileNode) => {
-    if (event.button !== 0 || file.type !== 'FILE') return;
+    if (event.button !== 0) return;
     pointerCandidateRef.current = {x: event.clientX, y: event.clientY, file};
   };
 
@@ -322,11 +322,8 @@ export const FileTable: React.FC<FileTableProps> = ({
   }, []);
 
   const getDragProps = (file: FileNode) => ({
-    draggable: file.type === 'FILE',
-    onDragStart: (e: React.DragEvent) => {
-      if (file.type !== 'FILE') return;
-      handleDragStart(e, file);
-    },
+    draggable: true,
+    onDragStart: (e: React.DragEvent) => handleDragStart(e, file),
     onDragEnd: handleDragEnd,
   });
 


### PR DESCRIPTION
## Summary
디렉토리도 파일과 동일하게 드래그 소스로 이동할 수 있도록 확장했습니다.

## Changes
- `getDragProps`에서 디렉토리 포함 전체 항목 draggable 허용
- `onDragStart` 파일 타입 가드 제거
- 제스처 기반 드래그 후보도 파일/디렉토리 공통 처리
- 기존 self-drop 방지 로직(`name !== targetDirectoryName`)은 유지

## Validation
- frontend build 통과
- 디렉토리 드래그 후 폴더 drop 이동 동작 확인

Closes #223
