### PR TITLE
Fix selection banner layout jump in file list

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -959,66 +959,75 @@ export const FileBrowser: React.FC = () => {
         )}
       </Stack>
 
-      {selectedFiles.size > 0 && (
-        <Paper
-          variant="outlined"
-          sx={{ mb: 2, p: 1.5, backgroundColor: 'primary.50', borderRadius: 2 }}
+      <Paper
+        variant="outlined"
+        sx={{
+          mb: 2,
+          p: 1.5,
+          borderRadius: 2,
+          minHeight: 66,
+          backgroundColor: selectedFiles.size > 0 ? 'primary.50' : 'background.paper',
+        }}
+      >
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          justifyContent="space-between"
         >
-          <Stack
-            direction={{ xs: 'column', sm: 'row' }}
-            spacing={1}
-            alignItems={{ xs: 'stretch', sm: 'center' }}
-            justifyContent="space-between"
-          >
-            <Typography variant="body2" sx={{ fontWeight: 600 }}>
-              {selectedFiles.size} item(s) selected · Shift for range, Cmd/Ctrl for toggle ·
-              Delete/F2/Enter shortcuts enabled
-            </Typography>
-            <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+          <Typography variant="body2" sx={{ fontWeight: 600, color: selectedFiles.size > 0 ? 'text.primary' : 'text.secondary' }}>
+            {selectedFiles.size > 0
+              ? `${selectedFiles.size} item(s) selected · Shift for range, Cmd/Ctrl for toggle · Delete/F2/Enter shortcuts enabled`
+              : 'No item selected · Select files/folders to use quick actions'}
+          </Typography>
+          <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+            <Button
+              size="small"
+              onClick={() => handleSelectionChange(new Set(visibleFiles.map((f) => f.name)))}
+              disabled={visibleFiles.length === 0}
+            >
+              Select All Visible
+            </Button>
+            {!isTrashView && (
               <Button
                 size="small"
-                onClick={() => handleSelectionChange(new Set(visibleFiles.map((f) => f.name)))}
+                color="warning"
+                onClick={() => void moveNamesToTrash(Array.from(selectedFiles))}
+                disabled={selectedFiles.size === 0}
               >
-                Select All Visible
+                Move to Trash
               </Button>
-              {!isTrashView && (
-                <Button
-                  size="small"
-                  color="warning"
-                  onClick={() => void moveNamesToTrash(Array.from(selectedFiles))}
-                >
-                  Move to Trash
-                </Button>
-              )}
-              {isTrashView && (
-                <Button
-                  size="small"
-                  color="success"
-                  onClick={() => void restoreNamesFromTrash(Array.from(selectedFiles))}
-                >
-                  Restore
-                </Button>
-              )}
-              {isTrashView && (
-                <Button
-                  size="small"
-                  color="error"
-                  onClick={() =>
-                    void deleteFiles(
-                      Array.from(selectedFiles).map((name) => `${TRASH_PATH}/${name}`)
-                    )
-                  }
-                >
-                  Delete Permanently
-                </Button>
-              )}
-              <Button size="small" onClick={clearSelection}>
-                Clear
+            )}
+            {isTrashView && (
+              <Button
+                size="small"
+                color="success"
+                onClick={() => void restoreNamesFromTrash(Array.from(selectedFiles))}
+                disabled={selectedFiles.size === 0}
+              >
+                Restore
               </Button>
-            </Stack>
+            )}
+            {isTrashView && (
+              <Button
+                size="small"
+                color="error"
+                onClick={() =>
+                  void deleteFiles(
+                    Array.from(selectedFiles).map((name) => `${TRASH_PATH}/${name}`)
+                  )
+                }
+                disabled={selectedFiles.size === 0}
+              >
+                Delete Permanently
+              </Button>
+            )}
+            <Button size="small" onClick={clearSelection} disabled={selectedFiles.size === 0}>
+              Clear
+            </Button>
           </Stack>
-        </Paper>
-      )}
+        </Stack>
+      </Paper>
 
       {isLoading && (
         <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>


### PR DESCRIPTION
## Summary
파일/디렉토리 선택 시 선택 배너가 새로 등장하면서 목록이 아래로 밀리던 레이아웃 점프를 제거했습니다.

## Changes
- 선택 배너 영역을 조건부 렌더링에서 상시 렌더링으로 변경
- 고정 최소 높이(`minHeight`)를 부여해 선택/해제 시 레이아웃 위치 유지
- 선택 없음 상태에서는 안내 문구 + 액션 비활성화
- 선택 있음 상태에서는 기존 액션 동작 유지

## Validation
- frontend build 통과
- 선택/해제 반복 시 파일 목록 Y 위치가 변하지 않는지 확인

Closes #225
