### PR TITLE
Fix drag HUD layout shift by using overlay rendering

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -721,16 +721,16 @@ export const FileBrowser: React.FC = () => {
         </Box>
       )}
 
-      {draggingCount > 0 && (
-        <Box
-          sx={{
-            position: 'sticky',
-            top: 8,
-            zIndex: 20,
-            mb: 2,
-            pointerEvents: 'none',
-          }}
-        >
+      <Box
+        sx={{
+          position: 'sticky',
+          top: 8,
+          zIndex: 20,
+          pointerEvents: 'none',
+          height: 0,
+        }}
+      >
+        {draggingCount > 0 && (
           <Paper
             elevation={4}
             sx={{
@@ -740,6 +740,7 @@ export const FileBrowser: React.FC = () => {
               border: `1px solid ${dragHoverTarget ? '#2e7d32' : '#90caf9'}`,
               backgroundColor: dragHoverTarget ? 'rgba(46,125,50,0.08)' : 'rgba(33,150,243,0.08)',
               transition: 'all 180ms ease',
+              transform: 'translateY(-6px)',
             }}
           >
             <Typography variant="body2" sx={{ fontWeight: 700 }}>
@@ -749,8 +750,8 @@ export const FileBrowser: React.FC = () => {
               {dragHoverTarget ? `Drop to: ${dragHoverTarget}` : 'Drag over a folder to choose destination'}
             </Typography>
           </Paper>
-        </Box>
-      )}
+        )}
+      </Box>
 
       {data && (
         <Paper variant="outlined" sx={{ mb: 2, p: 1.5, borderRadius: 2 }}>


### PR DESCRIPTION
## Summary
드래그 중 HUD 표시로 목록이 밀리던 레이아웃 점프를 제거했습니다.

## Changes
- 드래그 HUD 컨테이너를 항상 렌더링하되 `height: 0`으로 문서 흐름 비점유 처리
- 실제 HUD 패널은 드래그 중일 때만 오버레이로 표시
- 기존 상태 정보(이동 개수, 타겟 폴더)는 그대로 유지

## Validation
- frontend build 통과
- 드래그 시작/종료 시 목록 Y 위치가 고정되는지 확인

Closes #227
