### PR TITLE
Refine drag UX with non-overlapping floating status indicator

### DIFF
--- a/frontend/src/features/file-browser/ui/FileBrowser.tsx
+++ b/frontend/src/features/file-browser/ui/FileBrowser.tsx
@@ -721,37 +721,34 @@ export const FileBrowser: React.FC = () => {
         </Box>
       )}
 
-      <Box
-        sx={{
-          position: 'sticky',
-          top: 8,
-          zIndex: 20,
-          pointerEvents: 'none',
-          height: 0,
-        }}
-      >
-        {draggingCount > 0 && (
-          <Paper
-            elevation={4}
-            sx={{
-              px: 1.5,
-              py: 1,
-              borderRadius: 2,
-              border: `1px solid ${dragHoverTarget ? '#2e7d32' : '#90caf9'}`,
-              backgroundColor: dragHoverTarget ? 'rgba(46,125,50,0.08)' : 'rgba(33,150,243,0.08)',
-              transition: 'all 180ms ease',
-              transform: 'translateY(-6px)',
-            }}
-          >
-            <Typography variant="body2" sx={{ fontWeight: 700 }}>
-              Moving {draggingCount} item(s)
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              {dragHoverTarget ? `Drop to: ${dragHoverTarget}` : 'Drag over a folder to choose destination'}
-            </Typography>
-          </Paper>
-        )}
-      </Box>
+      {draggingCount > 0 && (
+        <Paper
+          elevation={8}
+          sx={{
+            position: 'fixed',
+            right: 24,
+            bottom: 64,
+            zIndex: (theme) => theme.zIndex.modal - 1,
+            px: 1.5,
+            py: 1,
+            borderRadius: 2,
+            border: `1px solid ${dragHoverTarget ? '#2e7d32' : '#90caf9'}`,
+            backgroundColor: dragHoverTarget ? 'rgba(46,125,50,0.14)' : 'rgba(33,150,243,0.12)',
+            backdropFilter: 'blur(4px)',
+            transition: 'all 180ms ease',
+            pointerEvents: 'none',
+            minWidth: 240,
+            maxWidth: 340,
+          }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 700 }}>
+            Moving {draggingCount} item(s)
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {dragHoverTarget ? `Drop to: ${dragHoverTarget}` : 'Drag over a folder to choose destination'}
+          </Typography>
+        </Paper>
+      )}
 
       {data && (
         <Paper variant="outlined" sx={{ mb: 2, p: 1.5, borderRadius: 2 }}>


### PR DESCRIPTION
## Summary
드래그 상태 배너가 상단 UI와 겹쳐 보이던 문제를 해결하기 위해 드래그 상태 표시 UX를 재구성했습니다.

## Changes
- 상단 인라인/스티키 배너 제거
- 하단 우측 고정 플로팅 인디케이터로 전환 (non-overlap)
- 아이템 수/타겟 폴더 정보를 컴팩트하게 유지
- pointer-events 비활성으로 드래그 조작 간섭 제거

## Validation
- frontend build 통과
- 드래그 중 기존 배너/필터와 시각 충돌 없이 상태 표시되는지 확인

Closes #229
